### PR TITLE
cicd: add build-and-test workflow for CI/CD integration

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,70 @@
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines in its README.
+
+name: build-and-test
+
+on:
+  push:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
+    runs-on: ubuntu-22.04
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro:
+          - humble
+          - jazzy
+        include:
+          - rosdistro: humble
+            container: ros:humble
+          - rosdistro: jazzy
+            container: ros:jazzy
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Show disk space before the tasks
+        run: df -h
+
+      - name: Remove exec_depend
+        uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
+
+      - name: Get self packages
+        id: get-self-packages
+        uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
+
+      - name: Build
+        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
+        uses: autowarefoundation/autoware-github-actions/colcon-build@v1
+        with:
+          rosdistro: ${{ matrix.rosdistro }}
+          target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+
+      - name: Test
+        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
+        id: test
+        uses: autowarefoundation/autoware-github-actions/colcon-test@v1
+        with:
+          rosdistro: ${{ matrix.rosdistro }}
+          target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+
+      - name: Upload coverage to CodeCov
+        if: ${{ steps.test.outputs.coverage-report-files != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ${{ steps.test.outputs.coverage-report-files }}
+          fail_ci_if_error: false
+          verbose: true
+          flags: total
+
+      - name: Show disk space after the tasks
+        run: df -h

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,6 +5,7 @@
 name: build-and-test
 
 on:
+  pull_request:
   push:
   schedule:
     - cron: 0 0 * * *

--- a/autoware_system_design_examples/CMakeLists.txt
+++ b/autoware_system_design_examples/CMakeLists.txt
@@ -13,4 +13,4 @@ add_library(${PROJECT_NAME} SHARED src/empty.cpp)
 
 autoware_system_designer_generate_launcher()
 
-autoware_system_designer_build_deploy(${PROJECT_NAME} vehicle_x.system PRINT_LEVEL=WARNING)
+autoware_system_designer_build_deploy(${PROJECT_NAME} vehicle_x.system PRINT_LEVEL=WARNING STRICT=ON)

--- a/autoware_system_designer/package.xml
+++ b/autoware_system_designer/package.xml
@@ -12,7 +12,9 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <build_depend>python3-jsonschema</build_depend>
+  <depend>python3-jinja2</depend>
+  <depend>python3-yaml</depend>
+  <depend>python3-jsonschema</depend>
 
   <exec_depend>ament_index_python</exec_depend>
 


### PR DESCRIPTION
- add build-and-test
- add python dependency to autoware_system_designer package
- make autoware_system_design_examples fail if the system build is failed