### PR TITLE
fix: generated component launcher did not had namespace

### DIFF
--- a/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
+++ b/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
@@ -73,16 +73,16 @@
   </include>
 {% elif node.launch_state == 'composable_node' %}
   <load_composable_node target="{{ node.container_target }}">
-    <composable_node pkg="{{ node.package }}" plugin="{{ node.plugin }}" name="{{ node.name }}" namespace="{{ node.full_namespace_path }}">
+    <composable_node pkg="{{ node.package }}" plugin="{{ node.plugin }}" name="{{ node.name }}" namespace="{{ node.namespace }}">
       {{ node_configuration(node)|indent(6) }}
     </composable_node>
   </load_composable_node>
 {% elif node.launch_state == 'node_container' %}
-  <node_container pkg="{{ node.package }}" exec="{{ node.executable }}" name="{{ node.name }}" namespace="{{ node.full_namespace_path }}" output="{{ node.node_output }}">
-    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
+  <node_container pkg="{{ node.package }}" exec="{{ node.executable }}" name="{{ node.name }}" namespace="{{ node.namespace }}" output="{{ node.node_output }}">
+    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace="{{ node.namespace }}"/>
   </node_container>
 {% else %}
-  <node pkg="{{ node.package }}" exec="{{ node.executable }}" name="{{ node.name }}" namespace="{{ node.full_namespace_path }}" output="{{ node.node_output }}"{% if node.args %} args="{{ node.args }}"{% endif %}>
+  <node pkg="{{ node.package }}" exec="{{ node.executable }}" name="{{ node.name }}" namespace="{{ node.namespace }}" output="{{ node.node_output }}"{% if node.args %} args="{{ node.args }}"{% endif %}>
     {{ node_configuration(node)|indent(4) }}
   </node>
 {% endif %}


### PR DESCRIPTION
fix bug may induced by https://github.com/autowarefoundation/autoware_system_designer/pull/43

update template to correctly export node namespace