### PR TITLE
feat: enhance launch configuration with intra-process communication support

### DIFF
--- a/autoware_system_designer/autoware_system_designer/building/config/launch_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/launch_manager.py
@@ -37,11 +37,13 @@ class LaunchManager:
         launch_config = LaunchConfig.from_config(config)
         return cls(launch_config=launch_config)
 
-    def update(self, container_target: str = ""):
+    def update(self, container_target: str = "", use_intra_process_comms: bool = False):
         """Update launch configuration with new container target and/or launch type."""
         if container_target:
             self.launch_config.container_target = container_target
             self.launch_config.launch_state = LaunchState.COMPOSABLE_NODE
+        if use_intra_process_comms:
+            self.launch_config.use_intra_process_comms = True
 
     @property
     def package_name(self) -> str:
@@ -70,6 +72,7 @@ class LaunchManager:
             case LaunchState.COMPOSABLE_NODE:
                 launcher_data["container_target"] = cfg.container_target
                 launcher_data["plugin"] = cfg.plugin
+                launcher_data["use_intra_process_comms"] = cfg.use_intra_process_comms
             case _:  # SINGLE_NODE
                 launcher_data["executable"] = cfg.executable
 

--- a/autoware_system_designer/autoware_system_designer/building/config/launch_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/launch_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from ..runtime.execution import LaunchConfig, LaunchState
 
@@ -37,13 +37,15 @@ class LaunchManager:
         launch_config = LaunchConfig.from_config(config)
         return cls(launch_config=launch_config)
 
-    def update(self, container_target: str = "", use_intra_process_comms: bool = False):
-        """Update launch configuration with new container target and/or launch type."""
+    def update(
+        self, container_target: str = "", use_intra_process_comms: Optional[bool] = None
+    ):
+        """Update launch configuration with a new container target and/or IPC setting."""
         if container_target:
             self.launch_config.container_target = container_target
             self.launch_config.launch_state = LaunchState.COMPOSABLE_NODE
-        if use_intra_process_comms:
-            self.launch_config.use_intra_process_comms = True
+        if use_intra_process_comms is not None:
+            self.launch_config.use_intra_process_comms = use_intra_process_comms
 
     @property
     def package_name(self) -> str:

--- a/autoware_system_designer/autoware_system_designer/building/config/launch_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/launch_manager.py
@@ -37,9 +37,7 @@ class LaunchManager:
         launch_config = LaunchConfig.from_config(config)
         return cls(launch_config=launch_config)
 
-    def update(
-        self, container_target: str = "", use_intra_process_comms: Optional[bool] = None
-    ):
+    def update(self, container_target: str = "", use_intra_process_comms: Optional[bool] = None):
         """Update launch configuration with a new container target and/or IPC setting."""
         if container_target:
             self.launch_config.container_target = container_target

--- a/autoware_system_designer/autoware_system_designer/building/instances/node_groups.py
+++ b/autoware_system_designer/autoware_system_designer/building/instances/node_groups.py
@@ -30,6 +30,24 @@ NODE_GROUP_CONTAINER_SPECS = {
             "type": "node_container",
         },
     },
+    "ros2_component_container_mt_icp": {
+        "package_name": "rclcpp_components",
+        "package_provider": "ros2",
+        "launch": {
+            "executable": "component_container_mt",
+            "type": "node_container",
+            "use_intra_process_comms": True,
+        },
+    },
+    "ros2_component_container_icp": {
+        "package_name": "rclcpp_components",
+        "package_provider": "ros2",
+        "launch": {
+            "executable": "component_container",
+            "type": "node_container",
+            "use_intra_process_comms": True,
+        },
+    },
 }
 
 
@@ -92,6 +110,8 @@ def apply_node_groups(instance: "Instance") -> None:
         )
         container_target_path = container_instance.path
 
+        use_ipc = NODE_GROUP_CONTAINER_SPECS[group_type]["launch"].get("use_intra_process_comms", False)
+
         for node_instance in matched_nodes:
             previous_target = node_instance.launch_manager.launch_config.container_target
             if previous_target and previous_target != container_target_path:
@@ -102,7 +122,10 @@ def apply_node_groups(instance: "Instance") -> None:
                     container_target_path,
                 )
 
-            node_instance.launch_manager.update(container_target=container_target_path)
+            node_instance.launch_manager.update(
+                container_target=container_target_path,
+                use_intra_process_comms=use_ipc,
+            )
 
 
 def _resolve_group_compute_unit(

--- a/autoware_system_designer/autoware_system_designer/building/instances/node_groups.py
+++ b/autoware_system_designer/autoware_system_designer/building/instances/node_groups.py
@@ -30,7 +30,7 @@ NODE_GROUP_CONTAINER_SPECS = {
             "type": "node_container",
         },
     },
-    "ros2_component_container_mt_icp": {
+    "ros2_component_container_mt_ipc": {
         "package_name": "rclcpp_components",
         "package_provider": "ros2",
         "launch": {
@@ -39,7 +39,7 @@ NODE_GROUP_CONTAINER_SPECS = {
             "use_intra_process_comms": True,
         },
     },
-    "ros2_component_container_icp": {
+    "ros2_component_container_ipc": {
         "package_name": "rclcpp_components",
         "package_provider": "ros2",
         "launch": {

--- a/autoware_system_designer/autoware_system_designer/building/runtime/execution.py
+++ b/autoware_system_designer/autoware_system_designer/building/runtime/execution.py
@@ -83,6 +83,7 @@ class LaunchConfig:
         executable = launch.get("executable", "")
         container_target = launch.get("container_target", launch.get("container_name", ""))
         launch_state = LaunchState.from_config(launch)
+        use_intra_process_comms = bool(launch.get("use_intra_process_comms", False))
 
         return cls(
             package_name=package_name,
@@ -93,6 +94,7 @@ class LaunchConfig:
             executable=executable,
             container_target=container_target,
             launch_state=launch_state,
+            use_intra_process_comms=use_intra_process_comms,
         )
 
     def apply_override(self, override: Dict[str, Any]) -> None:
@@ -107,6 +109,8 @@ class LaunchConfig:
             self.args = override["args"]
         if "container_target" in override:
             self.container_target = override["container_target"]
+        if "use_intra_process_comms" in override:
+            self.use_intra_process_comms = bool(override["use_intra_process_comms"])
 
         override_launch_state: Optional[LaunchState] = self.launch_state
         if "launch_state" in override and override["launch_state"] in LaunchState._value2member_map_:

--- a/autoware_system_designer/autoware_system_designer/building/runtime/execution.py
+++ b/autoware_system_designer/autoware_system_designer/building/runtime/execution.py
@@ -58,6 +58,7 @@ class LaunchConfig:
         executable: str = "",
         container_target: str = "",
         launch_state: LaunchState = LaunchState.SINGLE_NODE,
+        use_intra_process_comms: bool = False,
     ):
         self.package_name = package_name
         self.ros2_launch_file = ros2_launch_file
@@ -67,6 +68,7 @@ class LaunchConfig:
         self.executable = executable
         self.container_target = container_target
         self.launch_state = launch_state
+        self.use_intra_process_comms = use_intra_process_comms
 
     @classmethod
     def from_config(cls, config: Any) -> "LaunchConfig":

--- a/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
+++ b/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
@@ -75,6 +75,9 @@
   <load_composable_node target="{{ node.container_target }}">
     <composable_node pkg="{{ node.package }}" plugin="{{ node.plugin }}" name="{{ node.name }}" namespace="{{ node.namespace }}">
       {{ node_configuration(node)|indent(6) }}
+{% if node.use_intra_process_comms %}
+      <extra_arg name="use_intra_process_comms" value="true"/>
+{% endif %}
     </composable_node>
   </load_composable_node>
 {% elif node.launch_state == 'node_container' %}

--- a/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
+++ b/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
@@ -75,7 +75,7 @@
   <load_composable_node target="{{ node.container_target }}">
     <composable_node pkg="{{ node.package }}" plugin="{{ node.plugin }}" name="{{ node.name }}" namespace="{{ node.namespace }}">
       {{ node_configuration(node)|indent(6) }}
-{% if node.use_intra_process_comms %}
+{% if node.use_intra_process_comms|default(false) %}
       <extra_arg name="use_intra_process_comms" value="true"/>
 {% endif %}
     </composable_node>


### PR DESCRIPTION

- Added a new parameter `use_intra_process_comms` to the `LaunchManager` and `LaunchConfig` classes to enable intra-process communication for composable nodes.
- Updated the `update` method in `LaunchManager` to handle the new parameter, allowing for dynamic configuration of intra-process communication.
- Introduced new node group specifications in `node_groups.py` to support component containers with intra-process communication enabled.
- Modified the XML template in `component_launcher.xml.jinja2` to conditionally include the `use_intra_process_comms` argument based on the node configuration.

These changes improve the flexibility and performance of the Autoware System Designer by allowing for more efficient communication between nodes.