### PR TITLE
fix(link_manager, instance_tree): support node instance name with slash as additional namespace

### DIFF
--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -467,12 +467,12 @@ class LinkManager:
         port_list_to: Dict[str, _PortInfo] = {}
 
         # ports from children instances
-        for child_instance in self.instance.children.values():
+        for child_key, child_instance in self.instance.children.items():
             for port_name, port in child_instance.link_manager.in_ports.items():
-                idx = f"{child_instance.name}.{port_name}"
+                idx = f"{child_key}.{port_name}"
                 port_list_to[idx] = _PortInfo(port_name=port_name, instance=child_instance, port=port)
             for port_name, port in child_instance.link_manager.out_ports.items():
-                idx = f"{child_instance.name}.{port_name}"
+                idx = f"{child_key}.{port_name}"
                 port_list_from[idx] = _PortInfo(port_name=port_name, instance=child_instance, port=port)
 
         # ports from external interfaces

--- a/autoware_system_designer/autoware_system_designer/building/instances/instance_tree.py
+++ b/autoware_system_designer/autoware_system_designer/building/instances/instance_tree.py
@@ -190,10 +190,14 @@ def create_module_children(instance: "Instance", config_registry: "ConfigRegistr
             )
 
         child_name = cfg_node.get("name")
+        name_parts = child_name.split("/")
+        actual_name = name_parts[-1]
+        extra_ns = name_parts[:-1]
+        effective_ns = list(instance.resolved_path) + extra_ns
         child_instance = _create_child_instance(
-            child_name,
+            actual_name,
             instance.compute_unit,
-            instance.resolved_path,
+            effective_ns,
             instance,
             layer_delta=1,
         )
@@ -208,11 +212,11 @@ def create_module_children(instance: "Instance", config_registry: "ConfigRegistr
             )
         except Exception as e:
             # add the instance to the children dict for debugging
-            instance.children[child_instance.name] = child_instance
+            instance.children[child_name] = child_instance
             raise ValidationError(
-                f"Error in setting child instance {child_instance.name} : {e}, at {instance.configuration.file_path}"
+                f"Error in setting child instance {child_name} : {e}, at {instance.configuration.file_path}"
             )
-        instance.children[child_instance.name] = child_instance
+        instance.children[child_name] = child_instance
 
 
 def run_module_configuration(instance: "Instance") -> None:


### PR DESCRIPTION
* Problem
                                                                                                                                                                                                                                                  
  In module YAML definitions, instance names can contain slashes to express sub-namespacing, e.g.:                                                                                                                                                
  
  instances:                                                                                                                                                                                                                                      
    - name: detection/detection_by_tracker                                                                                                                                                                                                      
      entity: DetectionByTracker.node
                                                                                                                                                                                                                                                  
  The previous code passed the full slash-containing string directly as Instance.name. This caused two bugs:                                                                                                                                      
                                                                                                                                                                                                                                                  
  1. Invalid ROS 2 node name — a node name with a slash (e.g. detection/detection_by_tracker) is not valid in ROS 2.                                                                                                                              
  2. Malformed resolved_path — the slash was treated as a literal character in a single path segment instead of being interpreted as a namespace separator, so the resulting path had the wrong structure internally.                           
                                                                                                                                                                                                                                                  
* Fix                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                  
  building/instances/instance_tree.py — create_module_children                                                                                                                                                                                    
  
  Split the raw YAML name on / before constructing the child Instance:                                                                                                                                                                            
  - Last segment becomes the actual node name (detection_by_tracker)                                                                                                                                                                            
  - Preceding segments are appended to the parent's resolved_path as additional namespace (detection)                                                                                                                                             
  - The original full YAML name (e.g. detection/detection_by_tracker) is retained as the key in the parent's children dict, preserving all connection string lookups                                                                            
                                                                                                                                                                                                                                                  
  Works for any depth: ns1/ns2/nodename → name=nodename, extra namespace=[ns1, ns2].                                                                                                                                                              
                                                                                                                                                                                                                                                  
  building/graph/link_manager.py — set_links                                                                                                                                                                                                      
                                                                                                                                                                                                                                                  
  Changed port_list index construction from child_instance.name to the children dict key (child_key). Since connection strings in module YAML reference children by their original slash-path (e.g.                                               
  detection/detection_by_tracker.subscriber.tracked_objects), the port_list keys must use that same original key — not the split leaf name — for lookups to continue matching.