### PR TITLE
feat: default data_path to ~/autoware_data/ml_models

### DIFF
--- a/autoware_system_design_examples/deployment/vehicle_x.system.yaml
+++ b/autoware_system_design_examples/deployment/vehicle_x.system.yaml
@@ -9,7 +9,7 @@ override:
     - name: vehicle_id
       value: vehicle_x
     - name: data_path
-      value: $(env HOME)/autoware_data
+      value: $(env HOME)/autoware_data/ml_models
     - name: lanelet2_map_file
       value: lanelet2_map.osm
     - name: pointcloud_map_file


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7068
- Update the `data_path` value in `autoware_system_design_examples/deployment/vehicle_x.system.yaml` from `$(env HOME)/autoware_data` to `$(env HOME)/autoware_data/ml_models`, matching the new asset-typed `~/autoware_data/{maps,ml_models,...}/` layout and the corresponding update to the sibling `AutowareSample.system.yaml`.

## Why

The umbrella issue (autowarefoundation/autoware#7068) restructures the host-side data folder, with `~/autoware_data/ml_models/` as the home for ML model artifacts. The sample design `AutowareSample.system.yaml` in `autoware_launch` was already migrated (autowarefoundation/autoware_launch#1835); this is the matching one-line update for the `vehicle_x.system.yaml` deployment example so the two stay consistent.

---

- Pairs with autowarefoundation/autoware_launch#1835 (`AutowareSample.system.yaml` and the corresponding launch-arg defaults).

## Test plan

- [ ] One-line check: the resolved `data_path` matches the new layout:

  ```bash
  grep -n data_path autoware_system_design_examples/deployment/vehicle_x.system.yaml
  ```

  Expect: `value: $(env HOME)/autoware_data/ml_models`.

- [ ] [`autoware_system_design_examples/deployment/vehicle_x.system.yaml`](https://github.com/autowarefoundation/autoware_system_designer/blob/bb64830296f1eeee20642f94abf55f2c6f02dc05/autoware_system_design_examples/deployment/vehicle_x.system.yaml) renders correctly as a single-line override.
