### PR TITLE
feat: topic remapper

### DIFF
--- a/autoware_system_designer/autoware_system_designer/__init__.py
+++ b/autoware_system_designer/autoware_system_designer/__init__.py
@@ -14,14 +14,14 @@
 
 """Autoware System Designer Package."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.2"
 
 # The autoware_system_design_format version supported by this tool.
 # YAML design files declare their format version via the
 # ``autoware_system_design_format`` field (e.g. ``0.2.0``).
 # The tool accepts files whose *major* version matches and whose
 # *minor* version is less-than-or-equal-to the version below.
-DESIGN_FORMAT_VERSION = "0.3.0"
+DESIGN_FORMAT_VERSION = "0.3.2"
 
 __all__ = [
     "config",

--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -399,10 +399,11 @@ class LinkManager:
 
             from_port, to_port = self._resolve_ports_for_connection(connection, from_info, to_info)
 
-            if isinstance(to_port, InPort) and to_port.is_global:
+            if isinstance(to_port, InPort) and (to_port.is_remapped or to_port.is_global):
                 msg = (
-                    "[E_WILDCARD_GLOBAL_INPUT] Wildcard connection targets a global input port and "
-                    f"cannot create a link: '{connection.from_instance}.{connection.from_port_name}' -> "
+                    "[E_WILDCARD_PRESET_INPUT] Wildcard connection targets a preset input port "
+                    "(remapped or global) and cannot create a link: "
+                    f"'{connection.from_instance}.{connection.from_port_name}' -> "
                     f"'{connection.to_instance}.{connection.to_port_name}' "
                     f"(resolved target port: '{to_port.port_path}')"
                 )
@@ -497,6 +498,10 @@ class LinkManager:
         for ext_output in outputs:
             port_list_to[f".{ext_output.name}"] = _PortInfo(port_name=ext_output.name, instance=None, port=None)
 
+        # Apply remap entries before creating links so that link resolution in
+        # links.py sees is_remapped=True and preserves the overridden topic.
+        self.apply_remaps()
+
         # Establish links based on connection type
         for connection in connection_list:
             wildcard_fields = [
@@ -563,9 +568,9 @@ class LinkManager:
                     continue
 
                 from_port, to_port = self._resolve_ports_for_connection(connection, from_info, to_info)
-                if isinstance(to_port, InPort) and to_port.is_global:
+                if isinstance(to_port, InPort) and (to_port.is_remapped or to_port.is_global):
                     logger.warning(
-                        "Skipping connection targeting global input port "
+                        "Skipping connection targeting preset input port (remapped or global) "
                         f"'{to_port.port_path}'; Connection: '{from_key}' -> '{to_key}'"
                         + format_source(getattr(connection, "source", None))
                     )
@@ -574,6 +579,66 @@ class LinkManager:
 
         # Create external ports after links are set
         self._create_external_ports()
+
+    def apply_remaps(self):
+        """Apply topic remap entries from module/system config to child ports.
+
+        Remaps override node-level global topics.  When a lower (closer to
+        the system root) layer re-declares the same port the lower layer wins,
+        which is achieved naturally because system.set_links() calls this method
+        after module.set_links() has already run.
+
+        Back-propagation through the reference chain ensures that the node's own
+        port (used for launch-file remap args) also reflects the new topic.
+        """
+        remaps = getattr(self.instance.configuration, "remaps", None) or []
+        for entry in remaps:
+            parts = entry.source.split(".")
+            if len(parts) != 3:
+                raise ValidationError(
+                    f"[E_REMAP_SOURCE] Invalid remap source '{entry.source}': "
+                    "expected format '{instance}.{port_type}.{port_name}'"
+                )
+            instance_name, port_type, port_name = parts
+
+            child_instance = self.instance.children.get(instance_name)
+            if child_instance is None:
+                raise ValidationError(
+                    f"[E_REMAP_INSTANCE] Remap source instance '{instance_name}' not found. "
+                    f"Available: {list(self.instance.children.keys())}"
+                )
+
+            if port_type in ("publisher", "server"):
+                port = child_instance.link_manager.out_ports.get(port_name)
+            elif port_type in ("subscriber", "client"):
+                port = child_instance.link_manager.in_ports.get(port_name)
+            else:
+                raise ValidationError(
+                    f"[E_REMAP_PORT_TYPE] Invalid port type '{port_type}' in remap source "
+                    f"'{entry.source}'. Expected: publisher, subscriber, server, client"
+                )
+
+            if port is None:
+                if port_type in ("publisher", "server"):
+                    available = list(child_instance.link_manager.out_ports.keys())
+                else:
+                    available = list(child_instance.link_manager.in_ports.keys())
+                raise ValidationError(
+                    f"[E_REMAP_PORT] Port '{port_name}' not found in {port_type} ports of "
+                    f"'{instance_name}'. Available: {available}"
+                )
+
+            topic = entry.topic.lstrip("/")
+            topic_parts = topic.split("/")
+            self._force_remap_port(port, topic_parts)
+
+    @staticmethod
+    def _force_remap_port(port, topic_parts: list):
+        """Force-set a remapped topic on a port and back-propagate through its reference chain."""
+        port.is_remapped = True
+        port.topic = list(topic_parts)
+        for ref_port in port.reference:
+            LinkManager._force_remap_port(ref_port, topic_parts)
 
     def _create_external_ports(self):
         """Create external ports based on link list."""
@@ -685,7 +750,7 @@ class LinkManager:
         ports: List[LauncherPortData] = []
 
         for port in self.in_ports.values():
-            if not port.is_global and port.get_topic() == "":
+            if port.get_topic() == "":
                 continue
             ports.append(
                 {

--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -630,8 +630,18 @@ class LinkManager:
                     f"'{instance_name}'. Available: {available}"
                 )
 
+            if not entry.topic.startswith("/"):
+                raise ValidationError(
+                    f"[E_REMAP_TOPIC] Remap topic '{entry.topic}' must be an absolute ROS topic "
+                    f"starting with '/'"
+                )
             topic = entry.topic.lstrip("/")
             topic_parts = topic.split("/")
+            if not all(topic_parts):
+                raise ValidationError(
+                    f"[E_REMAP_TOPIC] Remap topic '{entry.topic}' contains empty segments; "
+                    "must be a valid absolute ROS topic (e.g. '/foo/bar')"
+                )
             self._force_remap_port(port, topic_parts)
 
     @staticmethod

--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -627,8 +627,7 @@ class LinkManager:
 
             if not entry.topic.startswith("/"):
                 raise ValidationError(
-                    f"[E_REMAP_TOPIC] Remap topic '{entry.topic}' must be an absolute ROS topic "
-                    f"starting with '/'"
+                    f"[E_REMAP_TOPIC] Remap topic '{entry.topic}' must be an absolute ROS topic " f"starting with '/'"
                 )
             topic = entry.topic.lstrip("/")
             topic_parts = topic.split("/")

--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -399,10 +399,10 @@ class LinkManager:
 
             from_port, to_port = self._resolve_ports_for_connection(connection, from_info, to_info)
 
-            if isinstance(to_port, InPort) and (to_port.is_remapped or to_port.is_global):
+            if isinstance(to_port, InPort) and to_port.is_global:
                 msg = (
-                    "[E_WILDCARD_PRESET_INPUT] Wildcard connection targets a preset input port "
-                    "(remapped or global) and cannot create a link: "
+                    "[E_WILDCARD_PRESET_INPUT] Wildcard connection targets a global input port "
+                    "and cannot create a link: "
                     f"'{connection.from_instance}.{connection.from_port_name}' -> "
                     f"'{connection.to_instance}.{connection.to_port_name}' "
                     f"(resolved target port: '{to_port.port_path}')"
@@ -568,9 +568,9 @@ class LinkManager:
                     continue
 
                 from_port, to_port = self._resolve_ports_for_connection(connection, from_info, to_info)
-                if isinstance(to_port, InPort) and (to_port.is_remapped or to_port.is_global):
+                if isinstance(to_port, InPort) and to_port.is_global:
                     logger.warning(
-                        "Skipping connection targeting preset input port (remapped or global) "
+                        "Skipping connection targeting global input port "
                         f"'{to_port.port_path}'; Connection: '{from_key}' -> '{to_key}'"
                         + format_source(getattr(connection, "source", None))
                     )

--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -581,12 +581,13 @@ class LinkManager:
         self._create_external_ports()
 
     def apply_remaps(self):
-        """Apply topic remap entries from system config to child ports.
+        """Apply topic remap entries from system config to child out-ports.
 
-        Remaps override node-level global topics.  When a lower (closer to
-        the system root) layer re-declares the same port the lower layer wins,
-        which is achieved naturally because system.set_links() calls this method
-        after module.set_links() has already run.
+        Only out-port types (publisher, server) may be remapped. Remaps override
+        node-level global topics. When a lower (closer to the system root) layer
+        re-declares the same port the lower layer wins, which is achieved naturally
+        because system.set_links() calls this method after module.set_links() has
+        already run.
 
         Back-propagation through the reference chain ensures that the node's own
         port (used for launch-file remap args) also reflects the new topic.
@@ -610,21 +611,15 @@ class LinkManager:
                     f"Available: {list(self.instance.children.keys())}"
                 )
 
-            if port_type in ("publisher", "server"):
-                port = child_instance.link_manager.out_ports.get(port_name)
-            elif port_type in ("subscriber", "client"):
-                port = child_instance.link_manager.in_ports.get(port_name)
-            else:
+            if port_type not in ("publisher", "server"):
                 raise ValidationError(
                     f"[E_REMAP_PORT_TYPE] Invalid port type '{port_type}' in remap source "
-                    f"'{entry.source}'. Expected: publisher, subscriber, server, client"
+                    f"'{entry.source}'. Only out-port types are allowed: publisher, server"
                 )
+            port = child_instance.link_manager.out_ports.get(port_name)
 
             if port is None:
-                if port_type in ("publisher", "server"):
-                    available = list(child_instance.link_manager.out_ports.keys())
-                else:
-                    available = list(child_instance.link_manager.in_ports.keys())
+                available = list(child_instance.link_manager.out_ports.keys())
                 raise ValidationError(
                     f"[E_REMAP_PORT] Port '{port_name}' not found in {port_type} ports of "
                     f"'{instance_name}'. Available: {available}"
@@ -645,26 +640,18 @@ class LinkManager:
             self._force_remap_port(port, topic_parts)
 
     @staticmethod
-    def _force_remap_port(port, topic_parts: list, visited: set = None):
-        """Force-set a remapped topic on a port and back-propagate through its reference chain."""
-        if visited is None:
-            visited = set()
-        port_id = id(port)
-        if port_id in visited:
-            return
-        visited.add(port_id)
+    def _force_remap_port(port: OutPort, topic_parts: list[str]):
+        """Force-set a remapped topic on an OutPort and back-propagate through its reference chain.
 
+        set_topic() propagates the topic to subscribed InPorts.
+        """
         port.is_remapped = True
-        # Use set_topic() so OutPort propagates the new topic to its users (InPorts).
-        # Guard for single-segment topics where namespace is empty.
         if len(topic_parts) == 1:
             port.set_topic([], topic_parts[0])
         else:
             port.set_topic(topic_parts[:-1], topic_parts[-1])
-        # InPort.set_topic() already recurses into references, but the visited guard prevents
-        # double-processing and ensures is_remapped is set on every port in the chain.
         for ref_port in port.reference:
-            LinkManager._force_remap_port(ref_port, topic_parts, visited)
+            LinkManager._force_remap_port(ref_port, topic_parts)
 
     def _create_external_ports(self):
         """Create external ports based on link list."""

--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -635,12 +635,26 @@ class LinkManager:
             self._force_remap_port(port, topic_parts)
 
     @staticmethod
-    def _force_remap_port(port, topic_parts: list):
+    def _force_remap_port(port, topic_parts: list, visited: set = None):
         """Force-set a remapped topic on a port and back-propagate through its reference chain."""
+        if visited is None:
+            visited = set()
+        port_id = id(port)
+        if port_id in visited:
+            return
+        visited.add(port_id)
+
         port.is_remapped = True
-        port.topic = list(topic_parts)
+        # Use set_topic() so OutPort propagates the new topic to its users (InPorts).
+        # Guard for single-segment topics where namespace is empty.
+        if len(topic_parts) == 1:
+            port.set_topic([], topic_parts[0])
+        else:
+            port.set_topic(topic_parts[:-1], topic_parts[-1])
+        # InPort.set_topic() already recurses into references, but the visited guard prevents
+        # double-processing and ensures is_remapped is set on every port in the chain.
         for ref_port in port.reference:
-            LinkManager._force_remap_port(ref_port, topic_parts)
+            LinkManager._force_remap_port(ref_port, topic_parts, visited)
 
     def _create_external_ports(self):
         """Create external ports based on link list."""

--- a/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/graph/link_manager.py
@@ -581,7 +581,7 @@ class LinkManager:
         self._create_external_ports()
 
     def apply_remaps(self):
-        """Apply topic remap entries from module/system config to child ports.
+        """Apply topic remap entries from system config to child ports.
 
         Remaps override node-level global topics.  When a lower (closer to
         the system root) layer re-declares the same port the lower layer wins,
@@ -591,7 +591,9 @@ class LinkManager:
         Back-propagation through the reference chain ensures that the node's own
         port (used for launch-file remap args) also reflects the new topic.
         """
-        remaps = getattr(self.instance.configuration, "remaps", None) or []
+        remaps = getattr(self.instance.configuration, "remaps", None)
+        if not remaps:
+            return
         for entry in remaps:
             parts = entry.source.split(".")
             if len(parts) != 3:

--- a/autoware_system_designer/autoware_system_designer/building/resolution/variant_resolver.py
+++ b/autoware_system_designer/autoware_system_designer/building/resolution/variant_resolver.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
-from ...parsing.config import ModuleConfig, NodeConfig, SystemConfig
+from ...parsing.config import ModuleConfig, NodeConfig, RemapEntry, SystemConfig
 from ...parsing.domain import ParameterFileDefinition, ParameterValueDefinition, PortDefinition
 from .connection_resolver import filter_connections_by_removed_entities
 
@@ -131,18 +131,21 @@ class VariantResolver:
             {'field': 'connections', 'key_field': None}
         ]
         The optional 'converter' callable converts override dict items to the appropriate typed object.
+        The optional 'yaml_key' overrides the YAML key used to look up the field in the override config
+        (defaults to 'field' when omitted).
         """
         override_config = config_yaml.get("override", {})
         for spec in merge_specs:
             field = spec["field"]
             key_field = spec["key_field"]
+            yaml_key = spec.get("yaml_key", field)
             converter: Optional[Callable] = spec.get("converter")
 
             # Get current list from object
             base_list = getattr(config_object, field)
 
             # Get override list from yaml (raw dicts)
-            override_list = override_config.get(field, [])
+            override_list = override_config.get(yaml_key, [])
 
             # Convert override items to typed objects if a converter is provided
             if converter and override_list:
@@ -193,6 +196,12 @@ class SystemVariantResolver(VariantResolver):
             {"field": "components", "key_field": "name"},
             {"field": "connections", "key_field": None},
             {"field": "node_groups", "key_field": "name"},
+            {
+                "field": "remaps",
+                "yaml_key": "remap",
+                "key_field": "source",
+                "converter": RemapEntry.from_dict,
+            },
         ]
         self._resolve_merges(system_config, config_yaml, merge_specs)
 

--- a/autoware_system_designer/autoware_system_designer/building/resolution/variant_resolver.py
+++ b/autoware_system_designer/autoware_system_designer/building/resolution/variant_resolver.py
@@ -165,10 +165,11 @@ class VariantResolver:
         for spec in remove_specs:
             field = spec["field"]
             key_field = spec["key_field"]
+            yaml_key = spec.get("yaml_key", field)
 
-            if field in remove_config:
+            if yaml_key in remove_config:
                 target_list = getattr(config_object, field)
-                remove_items = remove_config[field]
+                remove_items = remove_config[yaml_key]
 
                 result_list = self._remove_list(target_list, remove_items, key_field)
                 setattr(config_object, field, result_list)
@@ -198,7 +199,6 @@ class SystemVariantResolver(VariantResolver):
             {"field": "node_groups", "key_field": "name"},
             {
                 "field": "remaps",
-                "yaml_key": "remap",
                 "key_field": "source",
                 "converter": RemapEntry.from_dict,
             },
@@ -236,6 +236,7 @@ class SystemVariantResolver(VariantResolver):
             {"field": "variables", "key_field": "name"},
             {"field": "connections", "key_field": None},
             {"field": "node_groups", "key_field": "name"},
+            {"field": "remaps", "key_field": "source"},
         ]
         self._resolve_removals(system_config, remove_config, remove_specs)
 

--- a/autoware_system_designer/autoware_system_designer/building/runtime/links.py
+++ b/autoware_system_designer/autoware_system_designer/building/runtime/links.py
@@ -119,8 +119,8 @@ class Link:
                 to_port_ref.set_servers(from_port_list)
 
             # determine the topic, set it to the from-ports to publish and to-ports to subscribe
-            if getattr(from_port_ref, "is_global", False) and from_port_ref.topic:
-                # Global output: preserve the global topic; propagate it to subscribers
+            if (from_port_ref.is_remapped or from_port_ref.is_global) and from_port_ref.topic:
+                # Preset topic (remap takes priority over global): propagate to subscribers
                 topic_parts = from_port_ref.topic
                 for to_port_ref in to_port_list:
                     to_port_ref.set_topic(topic_parts[:-1], topic_parts[-1])
@@ -142,11 +142,14 @@ class Link:
             self.to_port.set_references(reference_port_list)
             # set the topic name to the external output, whether it is connected or not
             for reference_port in reference_port_list:
-                if getattr(reference_port, "is_global", False) and reference_port.topic:
-                    # Global output: preserve the global topic; propagate it to the external port
+                if (reference_port.is_remapped or reference_port.is_global) and reference_port.topic:
+                    # Preset topic (remap or global): propagate to the external port
                     topic_parts = reference_port.topic
                     self.to_port.set_topic(topic_parts[:-1], topic_parts[-1])
-                    self.to_port.is_global = True
+                    if reference_port.is_remapped:
+                        self.to_port.is_remapped = True
+                    else:
+                        self.to_port.is_global = True
                 else:
                     reference_port.set_topic(self.to_port.namespace, self.to_port.name)
 

--- a/autoware_system_designer/autoware_system_designer/building/runtime/ports.py
+++ b/autoware_system_designer/autoware_system_designer/building/runtime/ports.py
@@ -56,7 +56,7 @@ class Port:
         self.topic: List[str] = []
         self.event = None
         self.is_global = False
-        self.is_remapped = False  # True when topic is set by a module/system remap entry
+        self.is_remapped = False  # True when topic is set by a system remap entry
         self.remap_target = remap_target
 
     @property

--- a/autoware_system_designer/autoware_system_designer/building/runtime/ports.py
+++ b/autoware_system_designer/autoware_system_designer/building/runtime/ports.py
@@ -56,6 +56,7 @@ class Port:
         self.topic: List[str] = []
         self.event = None
         self.is_global = False
+        self.is_remapped = False  # True when topic is set by a module/system remap entry
         self.remap_target = remap_target
 
     @property

--- a/autoware_system_designer/autoware_system_designer/exporting/instance_to_json.py
+++ b/autoware_system_designer/autoware_system_designer/exporting/instance_to_json.py
@@ -83,6 +83,7 @@ def serialize_port(port, is_outward: bool = True) -> PortData:
         "namespace": port.namespace,
         "topic": port.topic,
         "is_global": port.is_global,
+        "is_remapped": port.is_remapped,
         "remap_target": port.remap_target,
         "port_path": port.port_path,
         "event": serialize_event(port.event),

--- a/autoware_system_designer/autoware_system_designer/exporting/schema.py
+++ b/autoware_system_designer/autoware_system_designer/exporting/schema.py
@@ -40,6 +40,7 @@ class PortData(TypedDict, total=False):
     namespace: List[str]
     topic: List[str]
     is_global: bool
+    is_remapped: bool
     remap_target: Optional[str]
     port_path: str
     event: Optional[EventData]

--- a/autoware_system_designer/autoware_system_designer/parsing/config.py
+++ b/autoware_system_designer/autoware_system_designer/parsing/config.py
@@ -23,7 +23,7 @@ from .domain import ParameterFileDefinition, ParameterValueDefinition, PortDefin
 class RemapEntry:
     """A single topic remap directive from system YAML."""
 
-    source: str  # '{instance}.{port_type}.{port_name}', e.g. 'vehicle_cmd_gate.publisher.engage'
+    source: str  # '{instance}.{port_type}.{port_name}', port_type must be 'publisher' or 'server'
     topic: str  # absolute ROS topic, e.g. '/api/autoware/get/engage'
 
     @classmethod

--- a/autoware_system_designer/autoware_system_designer/parsing/config.py
+++ b/autoware_system_designer/autoware_system_designer/parsing/config.py
@@ -19,6 +19,18 @@ from typing import Any, Dict, List, Optional, TypedDict, Union
 from .domain import ParameterFileDefinition, ParameterValueDefinition, PortDefinition
 
 
+@dataclass
+class RemapEntry:
+    """A single topic remap directive from module/system YAML."""
+
+    source: str  # '{instance}.{port_type}.{port_name}', e.g. 'vehicle_cmd_gate.publisher.engage'
+    topic: str  # absolute ROS topic, e.g. '/api/autoware/get/engage'
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "RemapEntry":
+        return cls(source=d["source"], topic=d["topic"])
+
+
 class LaunchConfigDict(TypedDict, total=False):
     plugin: str
     executable: str
@@ -175,3 +187,4 @@ class SystemConfig(Config):
     variables: Optional[List[VariableDict]] = None
     variable_files: Optional[List[VariableFileDict]] = None
     node_groups: Optional[List[NodeGroupDict]] = None
+    remaps: Optional[List[RemapEntry]] = None

--- a/autoware_system_designer/autoware_system_designer/parsing/config.py
+++ b/autoware_system_designer/autoware_system_designer/parsing/config.py
@@ -21,7 +21,7 @@ from .domain import ParameterFileDefinition, ParameterValueDefinition, PortDefin
 
 @dataclass
 class RemapEntry:
-    """A single topic remap directive from module/system YAML."""
+    """A single topic remap directive from system YAML."""
 
     source: str  # '{instance}.{port_type}.{port_name}', e.g. 'vehicle_cmd_gate.publisher.engage'
     topic: str  # absolute ROS topic, e.g. '/api/autoware/get/engage'

--- a/autoware_system_designer/autoware_system_designer/parsing/loaders/data_parser.py
+++ b/autoware_system_designer/autoware_system_designer/parsing/loaders/data_parser.py
@@ -321,7 +321,7 @@ class ConfigParser:
                         mode_configs[mode_name] = config[mode_name]
                         logger.debug(f"Found mode-specific configuration for mode '{mode_name}'")
 
-            raw_remaps = config.get("remap") or []
+            raw_remaps = config.get("remaps") or []
             return SystemConfig(
                 **base_data,
                 base=base_name,

--- a/autoware_system_designer/autoware_system_designer/parsing/loaders/data_parser.py
+++ b/autoware_system_designer/autoware_system_designer/parsing/loaders/data_parser.py
@@ -26,6 +26,7 @@ from ..config import (
     ModuleConfig,
     NodeConfig,
     ParameterSetConfig,
+    RemapEntry,
     SystemConfig,
 )
 from ..domain import ParameterFileDefinition, ParameterValueDefinition, PortDefinition
@@ -320,6 +321,7 @@ class ConfigParser:
                         mode_configs[mode_name] = config[mode_name]
                         logger.debug(f"Found mode-specific configuration for mode '{mode_name}'")
 
+            raw_remaps = config.get("remap") or []
             return SystemConfig(
                 **base_data,
                 base=base_name,
@@ -333,6 +335,7 @@ class ConfigParser:
                 variables=config.get("variables"),
                 variable_files=config.get("variable_files"),
                 node_groups=config.get("node_groups"),
+                remaps=[RemapEntry.from_dict(r) for r in raw_remaps],
             )
         else:
             raise ValidationError(f"Unknown entity type: {entity_type}")

--- a/autoware_system_designer/autoware_system_designer/schema/0.3.2/system.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.3.2/system.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "System Entity Schema 0.3.2",
+  "description": "Schema for autoware_system_design_format system entities",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "autoware_system_design_format": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "remove": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "variables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": ["string", "number", "boolean", "array"]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "variable_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "value"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "modes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "parameter_sets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "entity"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "entity": {
+            "type": "string"
+          },
+          "compute_unit": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "parameter_set": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "arguments": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "connections": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "type": "object",
+            "minProperties": 2,
+            "maxProperties": 2,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "node_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "nodes"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "nodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "remap": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "topic"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Port identifier: '{instance}.{port_type}.{port_name}' (port_type: publisher|subscriber|server|client)"
+          },
+          "topic": {
+            "type": "string",
+            "description": "Absolute ROS topic name (e.g. /api/autoware/get/engage)"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": true,
+  "if": {
+    "not": {
+      "required": ["base"]
+    }
+  },
+  "then": {
+    "required": ["components", "connections"]
+  }
+}

--- a/autoware_system_designer/autoware_system_designer/schema/0.3.2/system.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.3.2/system.json
@@ -163,7 +163,7 @@
         "additionalProperties": true
       }
     },
-    "remap": {
+    "remaps": {
       "type": "array",
       "items": {
         "type": "object",

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -638,8 +638,8 @@ class NodeDiagramModule extends DiagramBase {
       if (this.hasDragged) return;
       e.stopPropagation();
       this.updateInfoPanel(userData, "Node");
-      if (depth === 0) return;
       this.clearHighlights();
+      if (depth === 0) return;
 
       const nodeGroup = document.getElementById(node.id);
 

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -120,7 +120,7 @@ class NodeDiagramModule extends DiagramBase {
       const nodeHeight = Math.max(
         style.nodeBaseH,
         style.nodeBaseH +
-          maxPorts * (style.portSpacing * 3) +
+          maxPorts * (style.portSize + style.portSpacing * 2) +
           (containerTarget ? style.badgeH + style.badgePad : 0),
       );
 
@@ -314,7 +314,7 @@ class NodeDiagramModule extends DiagramBase {
     );
     hubNode.height = Math.max(
       style.nodeBaseH,
-      style.nodeBaseH + remappedPortEntries.length * (style.portSpacing * 3),
+      style.nodeBaseH + remappedPortEntries.length * (style.portSize + style.portSpacing * 2),
     );
 
     if (!rootNode.children) rootNode.children = [];
@@ -354,12 +354,12 @@ class NodeDiagramModule extends DiagramBase {
       nodeWidth: Math.round(120 * s),
       nodeBaseH: Math.round(44 * s),
       portSize: Math.round(5 * s),
-      portSpacing: Math.round(4 * s),
+      portSpacing: Math.round(2.5 * s),
       nodeSpacing: Math.round(5 * s),
-      edgeNodeSpacing: Math.round(3 * s),
-      edgeNodeBetweenLayers: Math.round(3 * s),
-      edgeEdgeSpacing: Math.round(4 * s),
-      edgeEdgeBetweenLayers: Math.round(4 * s),
+      edgeNodeSpacing: Math.round(2 * s),
+      edgeNodeBetweenLayers: Math.round(2 * s),
+      edgeEdgeSpacing: Math.round(3 * s),
+      edgeEdgeBetweenLayers: Math.round(3 * s),
       elkPadding: Math.round(20 * s),
       fontSize: Math.round(8 * s),
       nsSize: Math.round(5 * s),

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -227,7 +227,9 @@ class NodeDiagramModule extends DiagramBase {
     // Only collect boundary ports of top-level modules — inner ports also receive
     // is_remapped=true via _force_remap_port reference-chain propagation, so we
     // must restrict to ports whose parent node is a direct child of rootNode.
-    const topLevelNodeIds = new Set((rootNode?.children || []).map((c) => c.id));
+    const topLevelNodeIds = new Set(
+      (rootNode?.children || []).map((c) => c.id),
+    );
     const remappedPortEntries = [];
     for (const [id, data] of this.elementData) {
       if (
@@ -613,7 +615,9 @@ class NodeDiagramModule extends DiagramBase {
 
     if (userData.entity_type === "remap_hub") {
       fillColor = this.isDarkMode() ? "#2a1800" : "#fff8e1";
-      strokeColor = "#fd7e14";
+      strokeColor = this.isDarkMode()
+        ? defaults.dark.stroke
+        : defaults.light.stroke;
     }
 
     const rect = document.createElementNS(SVG_NS, "rect");
@@ -626,6 +630,7 @@ class NodeDiagramModule extends DiagramBase {
     if (userData.entity_type === "remap_hub") {
       const dw = parseFloat(style.borderW);
       rect.setAttribute("stroke-dasharray", `${dw * 5} ${dw * 2.5}`);
+      rect.setAttribute("stroke-linecap", "round");
     }
     rect.classList.add("node-rect");
 
@@ -650,7 +655,8 @@ class NodeDiagramModule extends DiagramBase {
             const fromId = String(edgeData.from_port?.unique_id ?? "");
             const toId = String(edgeData.to_port?.unique_id ?? "");
             const originalPortId = fromId === portId ? toId : fromId;
-            if (originalPortId) this._applyPortHighlight(originalPortId, "orange");
+            if (originalPortId)
+              this._applyPortHighlight(originalPortId, "orange");
           }
         }
         return;
@@ -866,13 +872,10 @@ class NodeDiagramModule extends DiagramBase {
     path.setAttribute("stroke-width", style.edgeW);
 
     if (edgeData.is_remap_edge) {
-      path.style.stroke = "#fd7e14";
       const ew = parseFloat(style.edgeW);
-      path.setAttribute("stroke-dasharray", `${ew * 6} ${ew * 3}`);
-      path.setAttribute(
-        "marker-end",
-        `url(#arrowhead-highlighted-orange-depth-${depth})`,
-      );
+      path.setAttribute("stroke-dasharray", `${ew} ${ew * 6}`);
+      path.setAttribute("stroke-linecap", "round");
+      path.setAttribute("marker-end", `url(#arrowhead-depth-${depth})`);
     } else {
       path.setAttribute("marker-end", `url(#arrowhead-depth-${depth})`);
     }
@@ -1060,13 +1063,8 @@ class NodeDiagramModule extends DiagramBase {
       if (el.tagName === "path") {
         const d = parseInt(el.getAttribute("data-depth") || "0", 10);
         const edgeData = this.elementData.get(el.id);
-        if (edgeData?.is_remap_edge) {
-          el.setAttribute("marker-end", `url(#arrowhead-highlighted-orange-depth-${d})`);
-          el.style.stroke = "#fd7e14";
-        } else {
-          el.setAttribute("marker-end", `url(#arrowhead-depth-${d})`);
-          el.style.stroke = "";
-        }
+        el.setAttribute("marker-end", `url(#arrowhead-depth-${d})`);
+        el.style.stroke = "";
         el.style.strokeWidth = "";
       }
     });

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -272,7 +272,6 @@ class NodeDiagramModule extends DiagramBase {
 
     let maxTopicW = 0;
     remappedPortEntries.forEach(({ id, data }) => {
-      const direction = this._getPortDirection(id) ?? "downstream";
       const hubPortId = `__remap_hub_port__${id}`;
       const topicName = data.topic?.length
         ? "/" + data.topic.join("/")
@@ -282,8 +281,6 @@ class NodeDiagramModule extends DiagramBase {
         this.measureTextWidth(topicName, style.portLabelFontSz),
       );
 
-      // publisher out_port (downstream) → hub WEST; subscriber in_port (upstream) → hub EAST
-      const side = direction === "downstream" ? "WEST" : "EAST";
       this.elementData.set(hubPortId, {
         unique_id: hubPortId,
         name: topicName,
@@ -298,7 +295,7 @@ class NodeDiagramModule extends DiagramBase {
         id: hubPortId,
         width: style.portSize,
         height: style.portSize,
-        properties: { "org.eclipse.elk.port.side": side },
+        properties: { "org.eclipse.elk.port.side": "WEST" },
         labels: [
           {
             text: topicName,
@@ -317,7 +314,7 @@ class NodeDiagramModule extends DiagramBase {
     );
     hubNode.height = Math.max(
       style.nodeBaseH,
-      style.nodeBaseH + remappedPortEntries.length * style.portSpacing * 3,
+      style.nodeBaseH + remappedPortEntries.length * (style.portSpacing * 3),
     );
 
     if (!rootNode.children) rootNode.children = [];
@@ -325,11 +322,10 @@ class NodeDiagramModule extends DiagramBase {
 
     if (!rootNode.edges) rootNode.edges = [];
     remappedPortEntries.forEach(({ id }) => {
-      const direction = this._getPortDirection(id) ?? "downstream";
       const hubPortId = `__remap_hub_port__${id}`;
       const edgeId = `__remap_edge__${id}`;
-      const [sources, targets] =
-        direction === "downstream" ? [[id], [hubPortId]] : [[hubPortId], [id]];
+      const sources = [id];
+      const targets = [hubPortId];
 
       this.elementData.set(edgeId, {
         unique_id: edgeId,
@@ -770,13 +766,7 @@ class NodeDiagramModule extends DiagramBase {
     const visGuide = userData.vis_guide || {};
 
     let prect;
-    if (isRemapHub) {
-      // Right-facing triangle: port on the remap hub block
-      prect = document.createElementNS(SVG_NS, "polygon");
-      const ps = port.width;
-      const h = ps / 2;
-      prect.setAttribute("points", `0,0 ${ps},${h} 0,${ps}`);
-    } else if (isRemapped) {
+    if (isRemapped) {
       // Circle: topic overridden by a module/system remap entry
       prect = document.createElementNS(SVG_NS, "circle");
       const r = port.width / 2;
@@ -798,10 +788,6 @@ class NodeDiagramModule extends DiagramBase {
       prect.setAttribute("height", port.height);
     }
     prect.classList.add("port-rect");
-    if (isRemapHub) {
-      prect.style.fill = "#fd7e14";
-      prect.style.stroke = "#fd7e14";
-    }
 
     const topicHint = portData.topic?.length
       ? " → /" + portData.topic.join("/")
@@ -871,13 +857,11 @@ class NodeDiagramModule extends DiagramBase {
     path.setAttribute("data-depth", String(depth));
     path.setAttribute("stroke-width", style.edgeW);
 
+    path.setAttribute("marker-end", `url(#arrowhead-depth-${depth})`);
     if (edgeData.is_remap_edge) {
       const ew = parseFloat(style.edgeW);
       path.setAttribute("stroke-dasharray", `${ew} ${ew * 6}`);
       path.setAttribute("stroke-linecap", "round");
-      path.setAttribute("marker-end", `url(#arrowhead-depth-${depth})`);
-    } else {
-      path.setAttribute("marker-end", `url(#arrowhead-depth-${depth})`);
     }
 
     path.onclick = (e) => {
@@ -1062,7 +1046,6 @@ class NodeDiagramModule extends DiagramBase {
       el.classList.remove("highlighted");
       if (el.tagName === "path") {
         const d = parseInt(el.getAttribute("data-depth") || "0", 10);
-        const edgeData = this.elementData.get(el.id);
         el.setAttribute("marker-end", `url(#arrowhead-depth-${d})`);
         el.style.stroke = "";
         el.style.strokeWidth = "";

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -767,7 +767,7 @@ class NodeDiagramModule extends DiagramBase {
 
     let prect;
     if (isRemapped) {
-      // Circle: topic overridden by a module/system remap entry
+      // Circle: topic overridden by a system remap entry
       prect = document.createElementNS(SVG_NS, "circle");
       const r = port.width / 2;
       prect.setAttribute("cx", r);
@@ -789,9 +789,10 @@ class NodeDiagramModule extends DiagramBase {
     }
     prect.classList.add("port-rect");
 
-    const topicHint = portData.topic?.length
-      ? " → /" + portData.topic.join("/")
-      : "";
+    const topicHint =
+      !isRemapHub && portData.topic?.length
+        ? " → /" + portData.topic.join("/")
+        : "";
     const titlePrefix = isRemapHub
       ? "[remap-topic]"
       : isRemapped

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -314,7 +314,8 @@ class NodeDiagramModule extends DiagramBase {
     );
     hubNode.height = Math.max(
       style.nodeBaseH,
-      style.nodeBaseH + remappedPortEntries.length * (style.portSize + style.portSpacing * 2),
+      style.nodeBaseH +
+        remappedPortEntries.length * (style.portSize + style.portSpacing * 2),
     );
 
     if (!rootNode.children) rootNode.children = [];

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -201,6 +201,7 @@ class NodeDiagramModule extends DiagramBase {
       delete rootNode.height;
       if (!rootNode.id) rootNode.id = "root";
     }
+    this._injectRemapHub(rootNode);
     return rootNode;
   }
 
@@ -220,6 +221,126 @@ class NodeDiagramModule extends DiagramBase {
       data.launcher?.container_target ||
       ""
     );
+  }
+
+  _injectRemapHub(rootNode) {
+    // Only collect boundary ports of top-level modules — inner ports also receive
+    // is_remapped=true via _force_remap_port reference-chain propagation, so we
+    // must restrict to ports whose parent node is a direct child of rootNode.
+    const topLevelNodeIds = new Set((rootNode?.children || []).map((c) => c.id));
+    const remappedPortEntries = [];
+    for (const [id, data] of this.elementData) {
+      if (
+        data.is_remapped === true &&
+        topLevelNodeIds.has(this.portToNode.get(id))
+      ) {
+        remappedPortEntries.push({ id, data });
+      }
+    }
+    if (remappedPortEntries.length === 0 || !rootNode) return;
+
+    const style = this.getLayerStyle(1);
+    const remapNodeId = "__remap_hub__";
+
+    this.elementData.set(remapNodeId, {
+      unique_id: remapNodeId,
+      name: "Remap Hub",
+      namespace: "System Remaps",
+      entity_type: "remap_hub",
+    });
+
+    const hubNode = {
+      id: remapNodeId,
+      labels: [{ text: "System Remaps" }, { text: "Remap Hub" }],
+      namespace: "System Remaps",
+      width: 0,
+      height: 0,
+      children: [],
+      ports: [],
+      properties: {
+        "org.eclipse.elk.portConstraints": "FIXED_SIDE",
+        "org.eclipse.elk.nodeLabels.placement": "H_CENTER V_TOP",
+        "org.eclipse.elk.portLabels.placement": "INSIDE",
+        "org.eclipse.elk.portAlignment.default": "CENTER",
+        "org.eclipse.elk.spacing.portPort": String(style.portSpacing),
+        "org.eclipse.elk.spacing.nodeNode": String(style.nodeSpacing),
+        "org.eclipse.elk.padding": `[top=${style.elkPadding},left=${style.elkPadding},bottom=${style.elkPadding},right=${style.elkPadding}]`,
+      },
+    };
+
+    let maxTopicW = 0;
+    remappedPortEntries.forEach(({ id, data }) => {
+      const direction = this._getPortDirection(id) ?? "downstream";
+      const hubPortId = `__remap_hub_port__${id}`;
+      const topicName = data.topic?.length
+        ? "/" + data.topic.join("/")
+        : data.name || "unknown";
+      maxTopicW = Math.max(
+        maxTopicW,
+        this.measureTextWidth(topicName, style.portLabelFontSz),
+      );
+
+      // publisher out_port (downstream) → hub WEST; subscriber in_port (upstream) → hub EAST
+      const side = direction === "downstream" ? "WEST" : "EAST";
+      this.elementData.set(hubPortId, {
+        unique_id: hubPortId,
+        name: topicName,
+        is_remap_hub_port: true,
+        original_port_id: id,
+        topic: data.topic,
+        msg_type: data.msg_type || "remap",
+      });
+      this.portToNode.set(hubPortId, remapNodeId);
+
+      hubNode.ports.push({
+        id: hubPortId,
+        width: style.portSize,
+        height: style.portSize,
+        properties: { "org.eclipse.elk.port.side": side },
+        labels: [
+          {
+            text: topicName,
+            width: this.measureTextWidth(topicName, style.portLabelFontSz),
+            height: style.portSize,
+          },
+        ],
+      });
+    });
+
+    const innerPad = style.portSize * 3;
+    hubNode.width = Math.max(
+      style.nodeWidth,
+      maxTopicW + innerPad,
+      this.measureTextWidth("Remap Hub", style.fontSize) + innerPad,
+    );
+    hubNode.height = Math.max(
+      style.nodeBaseH,
+      style.nodeBaseH + remappedPortEntries.length * style.portSpacing * 3,
+    );
+
+    if (!rootNode.children) rootNode.children = [];
+    rootNode.children.push(hubNode);
+
+    if (!rootNode.edges) rootNode.edges = [];
+    remappedPortEntries.forEach(({ id }) => {
+      const direction = this._getPortDirection(id) ?? "downstream";
+      const hubPortId = `__remap_hub_port__${id}`;
+      const edgeId = `__remap_edge__${id}`;
+      const [sources, targets] =
+        direction === "downstream" ? [[id], [hubPortId]] : [[hubPortId], [id]];
+
+      this.elementData.set(edgeId, {
+        unique_id: edgeId,
+        from_port: { unique_id: sources[0] },
+        to_port: { unique_id: targets[0] },
+        is_remap_edge: true,
+      });
+      [sources[0], targets[0]].forEach((portId) => {
+        if (!this.portToEdges.has(portId)) this.portToEdges.set(portId, []);
+        this.portToEdges.get(portId).push(edgeId);
+      });
+      rootNode.edges.push({ id: edgeId, sources, targets, properties: {} });
+    });
   }
 
   // ── Styling / metrics ────────────────────────────────────────────────────────
@@ -490,6 +611,11 @@ class NodeDiagramModule extends DiagramBase {
       if (depth === 0) fillColor = defaults.light.rootBg;
     }
 
+    if (userData.entity_type === "remap_hub") {
+      fillColor = this.isDarkMode() ? "#2a1800" : "#fff8e1";
+      strokeColor = "#fd7e14";
+    }
+
     const rect = document.createElementNS(SVG_NS, "rect");
     rect.setAttribute("width", node.width);
     rect.setAttribute("height", node.height);
@@ -497,15 +623,39 @@ class NodeDiagramModule extends DiagramBase {
     rect.setAttribute("fill", fillColor);
     rect.setAttribute("stroke", strokeColor);
     rect.setAttribute("stroke-width", style.borderW);
+    if (userData.entity_type === "remap_hub") {
+      const dw = parseFloat(style.borderW);
+      rect.setAttribute("stroke-dasharray", `${dw * 5} ${dw * 2.5}`);
+    }
     rect.classList.add("node-rect");
 
     rect.onclick = (e) => {
       if (this.hasDragged) return;
       e.stopPropagation();
       this.updateInfoPanel(userData, "Node");
+      if (depth === 0) return;
       this.clearHighlights();
 
       const nodeGroup = document.getElementById(node.id);
+
+      if (userData.entity_type === "remap_hub") {
+        nodeGroup?.classList.add("highlighted");
+        for (const [portId, nodeId] of this.portToNode) {
+          if (nodeId !== node.id) continue;
+          this._applyPortHighlight(portId, "orange");
+          for (const edgeId of this.portToEdges.get(portId) || []) {
+            const edgeData = this.elementData.get(edgeId);
+            if (!edgeData?.is_remap_edge) continue;
+            this._applyEdgeHighlight(edgeId, "orange");
+            const fromId = String(edgeData.from_port?.unique_id ?? "");
+            const toId = String(edgeData.to_port?.unique_id ?? "");
+            const originalPortId = fromId === portId ? toId : fromId;
+            if (originalPortId) this._applyPortHighlight(originalPortId, "orange");
+          }
+        }
+        return;
+      }
+
       if (node.children?.length) {
         this.highlightModule(node, nodeGroup);
       } else {
@@ -608,12 +758,19 @@ class NodeDiagramModule extends DiagramBase {
 
   _buildPortGroup(port, userData, style) {
     const portData = this.elementData.get(port.id) || {};
+    const isRemapHub = portData.is_remap_hub_port === true;
     const isRemapped = portData.is_remapped === true;
     const isGlobal = portData.is_global === true;
     const visGuide = userData.vis_guide || {};
 
     let prect;
-    if (isRemapped) {
+    if (isRemapHub) {
+      // Right-facing triangle: port on the remap hub block
+      prect = document.createElementNS(SVG_NS, "polygon");
+      const ps = port.width;
+      const h = ps / 2;
+      prect.setAttribute("points", `0,0 ${ps},${h} 0,${ps}`);
+    } else if (isRemapped) {
       // Circle: topic overridden by a module/system remap entry
       prect = document.createElementNS(SVG_NS, "circle");
       const r = port.width / 2;
@@ -635,11 +792,21 @@ class NodeDiagramModule extends DiagramBase {
       prect.setAttribute("height", port.height);
     }
     prect.classList.add("port-rect");
+    if (isRemapHub) {
+      prect.style.fill = "#fd7e14";
+      prect.style.stroke = "#fd7e14";
+    }
 
     const topicHint = portData.topic?.length
       ? " → /" + portData.topic.join("/")
       : "";
-    const titlePrefix = isRemapped ? "[remap]" : isGlobal ? "[global]" : "";
+    const titlePrefix = isRemapHub
+      ? "[remap-topic]"
+      : isRemapped
+        ? "[remap]"
+        : isGlobal
+          ? "[global]"
+          : "";
     const title = document.createElementNS(SVG_NS, "title");
     title.textContent = titlePrefix
       ? `${titlePrefix} ${portData.name || "Port"}${topicHint}`
@@ -689,15 +856,27 @@ class NodeDiagramModule extends DiagramBase {
       d += `L ${section.endPoint.x} ${section.endPoint.y} `;
     });
 
+    const edgeData = this.elementData.get(edge.id) || {};
+
     const path = document.createElementNS(SVG_NS, "path");
     path.setAttribute("id", edge.id);
     path.setAttribute("d", d);
     path.classList.add("edge-path");
     path.setAttribute("data-depth", String(depth));
     path.setAttribute("stroke-width", style.edgeW);
-    path.setAttribute("marker-end", `url(#arrowhead-depth-${depth})`);
 
-    const edgeData = this.elementData.get(edge.id) || {};
+    if (edgeData.is_remap_edge) {
+      path.style.stroke = "#fd7e14";
+      const ew = parseFloat(style.edgeW);
+      path.setAttribute("stroke-dasharray", `${ew * 6} ${ew * 3}`);
+      path.setAttribute(
+        "marker-end",
+        `url(#arrowhead-highlighted-orange-depth-${depth})`,
+      );
+    } else {
+      path.setAttribute("marker-end", `url(#arrowhead-depth-${depth})`);
+    }
+
     path.onclick = (e) => {
       if (this.hasDragged) return;
       e.stopPropagation();
@@ -880,8 +1059,14 @@ class NodeDiagramModule extends DiagramBase {
       el.classList.remove("highlighted");
       if (el.tagName === "path") {
         const d = parseInt(el.getAttribute("data-depth") || "0", 10);
-        el.setAttribute("marker-end", `url(#arrowhead-depth-${d})`);
-        el.style.stroke = "";
+        const edgeData = this.elementData.get(el.id);
+        if (edgeData?.is_remap_edge) {
+          el.setAttribute("marker-end", `url(#arrowhead-highlighted-orange-depth-${d})`);
+          el.style.stroke = "#fd7e14";
+        } else {
+          el.setAttribute("marker-end", `url(#arrowhead-depth-${d})`);
+          el.style.stroke = "";
+        }
         el.style.strokeWidth = "";
       }
     });

--- a/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
+++ b/autoware_system_designer/autoware_system_designer/visualization/js/node_diagram.js
@@ -608,11 +608,20 @@ class NodeDiagramModule extends DiagramBase {
 
   _buildPortGroup(port, userData, style) {
     const portData = this.elementData.get(port.id) || {};
+    const isRemapped = portData.is_remapped === true;
     const isGlobal = portData.is_global === true;
     const visGuide = userData.vis_guide || {};
 
     let prect;
-    if (isGlobal) {
+    if (isRemapped) {
+      // Circle: topic overridden by a module/system remap entry
+      prect = document.createElementNS(SVG_NS, "circle");
+      const r = port.width / 2;
+      prect.setAttribute("cx", r);
+      prect.setAttribute("cy", r);
+      prect.setAttribute("r", r);
+    } else if (isGlobal) {
+      // Diamond: topic fixed by node-level global key
       prect = document.createElementNS(SVG_NS, "polygon");
       const ps = port.width;
       const h = ps / 2;
@@ -627,8 +636,14 @@ class NodeDiagramModule extends DiagramBase {
     }
     prect.classList.add("port-rect");
 
+    const topicHint = portData.topic?.length
+      ? " → /" + portData.topic.join("/")
+      : "";
+    const titlePrefix = isRemapped ? "[remap]" : isGlobal ? "[global]" : "";
     const title = document.createElementNS(SVG_NS, "title");
-    title.textContent = portData.name || "Port";
+    title.textContent = titlePrefix
+      ? `${titlePrefix} ${portData.name || "Port"}${topicHint}`
+      : portData.name || "Port";
     prect.appendChild(title);
 
     const pg = document.createElementNS(SVG_NS, "g");

--- a/autoware_system_designer/pyproject.toml
+++ b/autoware_system_designer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autoware_system_designer"
-version = "0.3.0"
+version = "0.3.2"
 description = "Autoware System Designer Package for building and deploying Autoware systems."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
there are special case that a topic should be a specific topic name.

* external interface (as api)
  - control component has engage service `/api/autoware/set/engage` and message `/api/autoware/get/engage`
* simulation
  - AWSIM generates sensor data topics, exactly same topic name



**1. New `remaps` field in system YAML (schema v0.3.2)**
Systems can now declare topic overrides directly in their config file, bypassing the default topic that a node's port would otherwise publish/subscribe to:
```yaml
remaps:
  - source: vehicle_cmd_gate.publisher.engage
    topic: /api/autoware/get/engage
```
Source format is `{instance}.{port_type}.{port_name}`; topic must be an absolute ROS path (starts with `/`).

**2. Remap parsing, application, and port-flag propagation (`config.py`, `data_parser.py`, `link_manager.py`, `ports.py`, `links.py`)**
A typed `RemapEntry(source, topic)` dataclass is parsed from YAML into `SystemConfig`. During `set_links()`, `apply_remaps()` locates the target port in the child instance, validates the topic format, and calls `_force_remap_port()` — which sets `is_remapped = True` and back-propagates the new topic through the entire port reference chain so launch-file remap args are generated correctly. Wherever the codebase previously checked only `is_global` to preserve a preset topic or skip wildcard connections, it now also checks `is_remapped`, giving remapped topics the same (or higher) priority as global ones.

**3. "Remap Hub" node in the diagram visualizer (`node_diagram.js`)**
When remapped ports exist at the top level, a synthetic **Remap Hub** node is injected into the ELK graph. Each remapped port gets a corresponding hub port labeled with its absolute topic name, and dashed edges connect the hub ports back to the original ports — making system-level remaps immediately visible in the topology diagram.

<img width="1418" height="1257" alt="Screenshot from 2026-05-20 16-13-36" src="https://github.com/user-attachments/assets/173b55ae-04dc-48c1-a769-9941b5a5a531" />



to test this, please use working branches
* https://github.com/autowarefoundation/autoware_launch/pull/1810
* https://github.com/autowarefoundation/autoware_universe/pull/12408
