### PR TITLE
chore(ci): update GitHub Actions runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Update GitHub Actions runner from `ubuntu-22.04` to `ubuntu-24.04`
- 1 workflow file(s) updated
- `ubuntu-22.04-m` and other variant runners are unchanged

## Test plan
- [ ] Verify CI workflows run successfully on `ubuntu-24.04`
