### PR TITLE
feat: add design format 0.4.0 with description field

### DIFF
--- a/autoware_system_design_examples/deployment/vehicle_x.system.yaml
+++ b/autoware_system_design_examples/deployment/vehicle_x.system.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: vehicle_x.system
+
+description: Deployment of the TypeAlpha system for vehicle_x, overriding the vehicle id, data path and map file variables with concrete values.
 
 base: TypeAlpha.system
 

--- a/autoware_system_design_examples/design/module/perception/DetectorA.module.yaml
+++ b/autoware_system_design_examples/design/module/perception/DetectorA.module.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: DetectorA.module
+
+description: Detector A module combining a detector node and a map-based filter node into a single object-detection unit.
 
 instances:
   - name: node_detector

--- a/autoware_system_design_examples/design/module/perception/PerceptionA.module.yaml
+++ b/autoware_system_design_examples/design/module/perception/PerceptionA.module.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: PerceptionA.module
+
+description: Perception pipeline variant A - two detector modules and a CenterPoint detector feeding a tracker and predictor to produce predicted objects.
 
 instances:
   - name: detector_a1

--- a/autoware_system_design_examples/design/module/perception/PerceptionA.module.yaml
+++ b/autoware_system_design_examples/design/module/perception/PerceptionA.module.yaml
@@ -2,7 +2,7 @@ autoware_system_design_format: 0.4.0
 
 name: PerceptionA.module
 
-description: Perception pipeline variant A - two detector modules and a CenterPoint detector feeding a tracker and predictor to produce predicted objects.
+description: Perception pipeline variant A - two DetectorA modules feeding a tracker and predictor to produce predicted objects.
 
 instances:
   - name: detector_a1
@@ -11,6 +11,7 @@ instances:
     entity: DetectorA.module
   - name: node_tracker
     entity: Tracker.node
+    description: Fuses detections from both detectors into tracked objects.
   - name: node_predictor
     entity: Predictor.node
 
@@ -19,6 +20,7 @@ subscribers:
   - name: pointcloud
 publishers:
   - name: objects
+    description: Predicted objects for planning.
 
 connections:
   - - subscriber.pointcloud

--- a/autoware_system_design_examples/design/module/perception/PerceptionB.module.yaml
+++ b/autoware_system_design_examples/design/module/perception/PerceptionB.module.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: PerceptionB.module
+
+description: Perception pipeline variant B - a single detector feeding a tracker and predictor to produce predicted objects.
 
 instances:
   - name: detector_a1

--- a/autoware_system_design_examples/design/module/perception/TrafficLightRecognitionDummy.module.yaml
+++ b/autoware_system_design_examples/design/module/perception/TrafficLightRecognitionDummy.module.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: TrafficLightRecognitionDummy.module
+
+description: Traffic light recognition module wrapping the classification node and exposing car/pedestrian traffic-signal and detection ROI outputs.
 
 instances:
   - name: classification

--- a/autoware_system_design_examples/design/module/sensing/CameraDummy.module.yaml
+++ b/autoware_system_design_examples/design/module/sensing/CameraDummy.module.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: CameraDummy.module
+
+description: Camera sensing module - eight camera driver instances exposing per-camera image and camera_info outputs.
 
 instances:
   - name: camera_0

--- a/autoware_system_design_examples/design/module/sensing/LidarDummy.module.yaml
+++ b/autoware_system_design_examples/design/module/sensing/LidarDummy.module.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: LidarDummy.module
+
+description: LiDAR sensing module - four LiDAR driver instances plus a concatenation node, exposing both individual and concatenated point clouds.
 
 instances:
   - name: lidar_top

--- a/autoware_system_design_examples/design/module/sensing/RadarDummy.module.yaml
+++ b/autoware_system_design_examples/design/module/sensing/RadarDummy.module.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: RadarDummy.module
+
+description: Radar sensing module - six radar driver instances feeding detected- and tracked-object mergers, exposing the merged objects as the module outputs.
 
 instances:
   - name: radar_front_center

--- a/autoware_system_design_examples/design/node/ControlDummy.node.yaml
+++ b/autoware_system_design_examples/design/node/ControlDummy.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: ControlDummy.node
+
+description: Dummy control node that generates vehicle control, gear, hazard-light and turn-indicator commands from the planned route.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/LocalizationDummy.node.yaml
+++ b/autoware_system_design_examples/design/node/LocalizationDummy.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: LocalizationDummy.node
+
+description: Dummy localization node that fuses sensor inputs to publish pose, TF, acceleration and kinematic state.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/MapDummy.node.yaml
+++ b/autoware_system_design_examples/design/node/MapDummy.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: MapDummy.node
+
+description: Dummy map node that publishes the vector and point cloud maps and serves partial/differential point cloud map requests.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/PlanningDummy.node.yaml
+++ b/autoware_system_design_examples/design/node/PlanningDummy.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: PlanningDummy.node
+
+description: Dummy planning node that produces a mission route from the lanelet map and predicted objects.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/perception/DetectorA.node.yaml
+++ b/autoware_system_design_examples/design/node/perception/DetectorA.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: DetectorA.node
+
+description: Dummy ML-based detector that produces detected objects from an input point cloud.
 
 package:
   name: autoware_perception_dummy_nodes

--- a/autoware_system_design_examples/design/node/perception/DetectorA.node.yaml
+++ b/autoware_system_design_examples/design/node/perception/DetectorA.node.yaml
@@ -46,6 +46,7 @@ param_values:
 # processes
 processes:
   - name: detector
+    description: Runs detection on each input point cloud.
     trigger_conditions:
       - or:
           - on_input: pointcloud

--- a/autoware_system_design_examples/design/node/perception/FilterA.node.yaml
+++ b/autoware_system_design_examples/design/node/perception/FilterA.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: FilterA.node
+
+description: Dummy object filter that uses the vector map to constrain incoming detected objects.
 
 package:
   name: autoware_perception_dummy_nodes

--- a/autoware_system_design_examples/design/node/perception/Predictor.node.yaml
+++ b/autoware_system_design_examples/design/node/perception/Predictor.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: Predictor.node
+
+description: Dummy predictor that produces predicted objects from tracked objects and the lanelet map.
 
 package:
   name: autoware_perception_dummy_nodes

--- a/autoware_system_design_examples/design/node/perception/Tracker.node.yaml
+++ b/autoware_system_design_examples/design/node/perception/Tracker.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: Tracker.node
+
+description: Dummy multi-object tracker that fuses detected objects from multiple detectors into tracked objects.
 
 package:
   name: autoware_perception_dummy_nodes

--- a/autoware_system_design_examples/design/node/perception/TrafficLightRecognitionDummy.node.yaml
+++ b/autoware_system_design_examples/design/node/perception/TrafficLightRecognitionDummy.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: TrafficLightRecognitionDummy.node
+
+description: Dummy traffic light recognition node that publishes car/pedestrian traffic signals and detection ROIs.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/sensing/CameraDummyDriver.node.yaml
+++ b/autoware_system_design_examples/design/node/sensing/CameraDummyDriver.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: CameraDummyDriver.node
+
+description: Dummy camera driver that periodically publishes raw image, compressed image and camera info.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/sensing/ConcatenatePointcloudDummy.node.yaml
+++ b/autoware_system_design_examples/design/node/sensing/ConcatenatePointcloudDummy.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: ConcatenatePointcloudDummy.node
+
+description: Dummy preprocessing node that concatenates up to eight LiDAR point clouds into a single output cloud.
 
 package:
   name: autoware_pointcloud_preprocessor

--- a/autoware_system_design_examples/design/node/sensing/DetectedObjectMergerDummy6.node.yaml
+++ b/autoware_system_design_examples/design/node/sensing/DetectedObjectMergerDummy6.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: DetectedObjectMergerDummy6.node
+
+description: Dummy node that merges detected objects from up to six input sources into a single output.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/sensing/LidarDummyDriver.node.yaml
+++ b/autoware_system_design_examples/design/node/sensing/LidarDummyDriver.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: LidarDummyDriver.node
+
+description: Dummy LiDAR driver that publishes a point cloud at a fixed rate.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/sensing/RadarDummyDriver.node.yaml
+++ b/autoware_system_design_examples/design/node/sensing/RadarDummyDriver.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: RadarDummyDriver.node
+
+description: Dummy radar driver that periodically publishes detected and tracked objects.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/node/sensing/TrackedObjectMergerDummy6.node.yaml
+++ b/autoware_system_design_examples/design/node/sensing/TrackedObjectMergerDummy6.node.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: TrackedObjectMergerDummy6.node
+
+description: Dummy node that merges tracked objects from up to six input sources into a single output.
 
 package:
   name: autoware_system_dummy_modules

--- a/autoware_system_design_examples/design/parameter_set/PerceptionModuleA.parameter_set.yaml
+++ b/autoware_system_design_examples/design/parameter_set/PerceptionModuleA.parameter_set.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: PerceptionModuleA.parameter_set
+
+description: Parameter set binding param files and values for the nodes of the PerceptionA perception module.
 
 parameters:
   - node: /perception/object_recognition/detector_a1/node_detector

--- a/autoware_system_design_examples/design/parameter_set/PerceptionModuleABuild.parameter_set.yaml
+++ b/autoware_system_design_examples/design/parameter_set/PerceptionModuleABuild.parameter_set.yaml
@@ -2,10 +2,11 @@ autoware_system_design_format: 0.4.0
 
 name: PerceptionModuleABuild.parameter_set
 
-description: Parameter set for building the perception module A.
+description: Build pass for perception module A - runs the detector_a1 detector node with build_only enabled to prebuild the model engine.
 
 parameters:
   - node: /perception/object_recognition/detector_a1/node_detector
+    description: Enable build-only mode on the detector node.
     param_values:
       - name: build_only
         type: bool

--- a/autoware_system_design_examples/design/parameter_set/PerceptionModuleABuild.parameter_set.yaml
+++ b/autoware_system_design_examples/design/parameter_set/PerceptionModuleABuild.parameter_set.yaml
@@ -1,6 +1,9 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 name: PerceptionModuleABuild.parameter_set
+
+description: Parameter set for building the perception module A.
+
 parameters:
   - node: /perception/object_recognition/detector_a1/node_detector
     param_values:

--- a/autoware_system_design_examples/design/system/TypeAlpha.system.yaml
+++ b/autoware_system_design_examples/design/system/TypeAlpha.system.yaml
@@ -1,6 +1,8 @@
-autoware_system_design_format: 0.3.1
+autoware_system_design_format: 0.4.0
 
 name: TypeAlpha.system
+
+description: System configuration for Type Alpha, demo configuration.
 
 variables:
   - name: vehicle_id

--- a/autoware_system_design_examples/design/system/TypeAlpha.system.yaml
+++ b/autoware_system_design_examples/design/system/TypeAlpha.system.yaml
@@ -2,10 +2,11 @@ autoware_system_design_format: 0.4.0
 
 name: TypeAlpha.system
 
-description: System configuration for Type Alpha, demo configuration.
+description: Demo system Type Alpha - dummy sensing, map, localization, perception and planning components spread over main_ecu and dummy ECUs, with a simulation mode that swaps the perception module.
 
 variables:
   - name: vehicle_id
+    description: Identifier of the target vehicle, set by the deployment.
   - name: data_path
   - name: lanelet2_map_file
   - name: pointcloud_map_file
@@ -32,6 +33,7 @@ components:
     compute_unit: dummy_ecu_1
   - name: object_recognition
     entity: PerceptionA.module
+    description: LiDAR object recognition pipeline.
     path: /perception/object_recognition
     compute_unit: main_ecu
     parameter_set: [PerceptionModuleA.parameter_set]

--- a/autoware_system_designer.instructions.md
+++ b/autoware_system_designer.instructions.md
@@ -29,6 +29,7 @@ Represents a single ROS 2 node.
 
 - `autoware_system_design_format`: Must be a version up to the supported `DESIGN_FORMAT_VERSION`.
 - `name`: Must match filename (e.g., `MyNode.node`).
+- `description`: (Optional) Brief explanation of the node's role.
 - `package`: Dictionary defining the ROS 2 package information.
   - `name`: ROS 2 package name.
   - `provider`: Provider of the package (e.g., `dummy`, `tier4`, `autoware`).
@@ -39,6 +40,7 @@ Represents a single ROS 2 node.
   - `node_output`: (Optional) `screen`, `log`, etc.
 - `subscribers`: List of input ports (subscribers).
   - `name`: Port name. Can include slashes (e.g., `perception/objects`).
+  - `description`: (Optional) Brief explanation of the port.
   - `message_type`: Full ROS message type (e.g., `sensor_msgs/msg/PointCloud2`).
   - `remap_target`: (Optional) The internal ROS 2 topic name used by the node.
     - **Default**: If not provided, it defaults to `~/input/<name>`.
@@ -47,6 +49,7 @@ Represents a single ROS 2 node.
   - `qos`: (Optional) QoS settings (`reliability`, `durability`, etc.).
 - `publishers`: List of output ports (publishers).
   - `name`: Port name. Can include slashes.
+  - `description`: (Optional) Brief explanation of the port.
   - `message_type`: Full ROS message type.
   - `qos`: (Optional) QoS settings (`reliability`, `durability`, etc.).
   - `remap_target`: (Optional) The internal ROS 2 topic name used by the node.
@@ -55,18 +58,21 @@ Represents a single ROS 2 node.
   - `global`: (Optional) If set, the output topic is published to a global topic name (e.g., `/tf`).
 - `servers`: (Optional) List of service/action servers.
   - `name`: Server name.
+  - `description`: (Optional) Brief explanation of the server.
   - `message_type`: Full ROS service or action type (e.g., `std_srvs/srv/SetBool` or `example_interfaces/action/Fibonacci`).
   - `global`: (Optional) If set, the server uses a global topic name.
   - `qos`: (Optional) QoS settings.
   - `remap_target`: (Optional) The internal ROS 2 service/action name used by the node.
 - `clients`: (Optional) List of service/action clients.
   - `name`: Client name.
+  - `description`: (Optional) Brief explanation of the client.
   - `message_type`: Full ROS service or action type (e.g., `std_srvs/srv/SetBool` or `example_interfaces/action/Fibonacci`).
   - `global`: (Optional) If set, the client uses a global topic name.
   - `qos`: (Optional) QoS settings.
   - `remap_target`: (Optional) The internal ROS 2 service/action name used by the node.
 - `param_files`: List of parameter file references. Can be an empty list `[]`.
   - `name`: Identifier for the file reference.
+  - `description`: (Optional) Brief explanation of the file reference.
   - `default`: Path to file (use `$(find-pkg-share pkg)/path` or relative path).
   - `schema`: (Optional) Path to JSON schema.
   - `allow_substs`: (Optional) `true`/`false` to allow substitution in parameter files.
@@ -77,6 +83,7 @@ Represents a single ROS 2 node.
   - `description`: (Optional) Brief explanation of the parameter.
 - `processes`: Execution logic / Event chains.
   - `name`: Name of the process/callback.
+  - `description`: (Optional) Brief explanation of the process.
   - `trigger_conditions`: Logic to start process. Can be nested with `or`/`and`.
     - `on_input`: Triggered by input port (`on_input: port_name`).
     - `on_trigger`: Triggered by another process (`on_trigger: process_name`).
@@ -95,19 +102,25 @@ Represents a composite component containing nodes or other modules.
 
 - `autoware_system_design_format`: Must be a version up to the supported `DESIGN_FORMAT_VERSION`.
 - `name`: Must match filename (e.g., `MyModule.module`).
+- `description`: (Optional) Brief explanation of the module's role.
 - `instances`: List of internal entities.
   - `name`: Local name for the instance (e.g., `lidar_driver`).
   - `entity`: Reference to the entity definition (e.g., `LidarDriver.node`).
+  - `description`: (Optional) Brief explanation of the instance.
   - `launch`: (Optional) Override launch configurations for this instance.
 - `subscribers`: List of externally accessible input ports.
   - `name`: Port name.
+  - `description`: (Optional) Brief explanation of the port.
 - `publishers`: List of externally accessible output ports.
   - `name`: Port name.
+  - `description`: (Optional) Brief explanation of the port.
 - `servers`: (Optional) List of externally accessible service/action servers.
   - `name`: Server name.
+  - `description`: (Optional) Brief explanation of the server.
 - `clients`: (Optional) List of externally accessible service/action clients.
   - `name`: Client name.
-- `connections`: Internal wiring. List of connection pairs, where each connection is a list of two port paths. Supports wildcards (e.g., `subscriber.*` or `node.publisher.*`).
+  - `description`: (Optional) Brief explanation of the client.
+- `connections`: Internal wiring. List of connection pairs, where each connection is a list of two port paths. Supports wildcards (e.g., `subscriber.*` or `node.publisher.*`). Connection entries do not take a `description`.
 
 **Connection Syntax:**
 
@@ -164,14 +177,18 @@ Top-level entry point defining the complete system.
 
 - `autoware_system_design_format`: Must be a version up to the supported `DESIGN_FORMAT_VERSION`.
 - `name`: Must match filename (e.g., `MyCar.system`).
+- `description`: (Optional) Brief explanation of the system.
 - `arguments`: (Optional) List of system arguments.
   - `name`: Argument name.
+  - `description`: (Optional) Brief explanation of the argument.
 - `variables`: List of system variables.
   - `name`: Variable name.
   - `value`: Variable value (supports `$(find-pkg-share pkg)` and `$(env VAR)` substitutions).
+  - `description`: (Optional) Brief explanation of the variable.
 - `variable_files`: (Optional) List of variable file references.
   - `name`: Variable file identifier.
   - `value`: Path to variable file.
+  - `description`: (Optional) Brief explanation of the file reference.
 - `modes`: List of operation modes.
   - `name`: Mode name (e.g., `Runtime`, `LoggingSimulation`).
   - `description`: (Optional) Description of the mode.
@@ -180,6 +197,7 @@ Top-level entry point defining the complete system.
 - `components`: Top-level instances.
   - `name`: Name of the component instance.
   - `entity`: Reference to module/node (e.g., `SensingModule.module`).
+  - `description`: (Optional) Brief explanation of the component.
   - `namespace`: ROS namespace prefix.
   - `compute_unit`: Hardware resource identifier (e.g., `main_ecu`).
   - `parameter_set`: (Optional) Parameter set file name(s) to apply. Can be a string or an array of strings.
@@ -187,7 +205,7 @@ Top-level entry point defining the complete system.
   - `name`: Unique group name. It will be used as the component name for the container.
   - `type`: Node group execution type. select `ros2_component_container_mt` or `ros2_component_container`.
   - `nodes`: List of non-empty path patterns. Glob patterns (`*`, `?`, `[...]`) match the full node path.
-- `connections`: Top-level wiring between components. List of connection pairs, where each connection is a list of two port paths. Supports wildcards (e.g., `component.publisher.^` for wildcard).
+- `connections`: Top-level wiring between components. List of connection pairs, where each connection is a list of two port paths. Supports wildcards (e.g., `component.publisher.^` for wildcard). Connection entries do not take a `description`.
 
 **Mode-Specific Overrides:**
 Each mode can define overrides using the mode name as a key:
@@ -202,8 +220,10 @@ Overrides parameters for specific nodes within the system hierarchy.
 
 - `autoware_system_design_format`: Must be a version up to the supported `DESIGN_FORMAT_VERSION`.
 - `name`: Must match filename.
+- `description`: (Optional) Brief explanation of the parameter set.
 - `parameters`: List of overrides.
   - `node`: Full hierarchical path to the node instance (e.g., `/perception/object_recognition/detector_a1/node_detector`).
+  - `description`: (Optional) Brief explanation of the override entry.
   - `param_files`: List of dictionaries mapping parameter file keys to new paths.
     - Format: `- <key>: <path>` (e.g., `- model_param_path: path/to/file.yaml`).
   - `param_values`: List of individual parameter value overrides.
@@ -270,11 +290,12 @@ Removals are applied **before** overrides to ensure removed items don't interfer
 
 ## 7. Examples
 
-### Node Example (0.3.0)
+### Node Example (0.4.0)
 
 ```yaml
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 name: Detector.node
+description: Camera-based object detector.
 package:
   name: my_perception
   provider: tier4
@@ -290,6 +311,7 @@ subscribers:
     global: /tf
 publishers:
   - name: objects
+    description: Detected objects in the camera frame.
     message_type: autoware_perception_msgs/msg/DetectedObjects
     qos:
       reliability: reliable
@@ -306,10 +328,10 @@ processes:
       - to_output: objects
 ```
 
-### Module Example (0.3.0)
+### Module Example (0.4.0)
 
 ```yaml
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 name: DetectorA.module
 instances:
   - name: node_detector
@@ -332,10 +354,10 @@ connections:
     - publisher.*
 ```
 
-### System Example (0.3.0)
+### System Example (0.4.0)
 
 ```yaml
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 name: AutowareSample.system
 variables:
   - name: config_path
@@ -381,10 +403,10 @@ LoggingSimulation:
           - /sensing
 ```
 
-### Parameter Set Example (0.3.0)
+### Parameter Set Example (0.4.0)
 
 ```yaml
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 name: PerceptionModuleA.parameter_set
 parameters:
   - node: /perception/object_recognition/detector_a1/node_detector

--- a/autoware_system_designer/autoware_system_designer/__init__.py
+++ b/autoware_system_designer/autoware_system_designer/__init__.py
@@ -19,7 +19,7 @@
 # ``autoware_system_design_format`` field (e.g. ``0.2.0``).
 # The tool accepts files whose *major* version matches and whose
 # *minor* version is less-than-or-equal-to the version below.
-DESIGN_FORMAT_VERSION = "0.3.2"
+DESIGN_FORMAT_VERSION = "0.4.0"
 
 __all__ = [
     "config",

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/module.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/module.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Module Entity Schema 0.4.0",
+  "description": "Schema for autoware_system_design_format module entities",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "autoware_system_design_format": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "remove": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "instances": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "entity"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "entity": {
+            "type": "string"
+          },
+          "launch": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "subscribers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "publishers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "clients": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "connections": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "type": "object",
+            "minProperties": 2,
+            "maxProperties": 2,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "if": {
+    "not": {
+      "required": ["base"]
+    }
+  },
+  "then": {
+    "required": ["instances", "subscribers", "publishers", "connections"]
+  }
+}

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/module.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/module.json
@@ -37,6 +37,9 @@
           "entity": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "launch": {
             "type": "object",
             "additionalProperties": true
@@ -53,6 +56,9 @@
         "properties": {
           "name": {
             "type": "string"
+          },
+          "description": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -65,6 +71,9 @@
         "required": ["name"],
         "properties": {
           "name": {
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           }
         },
@@ -79,6 +88,9 @@
         "properties": {
           "name": {
             "type": "string"
+          },
+          "description": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -91,6 +103,9 @@
         "required": ["name"],
         "properties": {
           "name": {
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           }
         },

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/node.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/node.json
@@ -256,6 +256,9 @@
           "name": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "trigger_conditions": {
             "type": "array"
           },

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/node.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/node.json
@@ -1,0 +1,287 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Node Entity Schema 0.4.0",
+  "description": "Schema for autoware_system_design_format node entities",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "autoware_system_design_format": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "remove": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "package": {
+      "type": "object",
+      "required": ["name", "provider"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "launch": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "subscribers": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "message_type"],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "message_type": {
+                "type": "string",
+                "pattern": "^[^/]+/msg/[^/]+$"
+              },
+              "description": {
+                "type": "string"
+              },
+              "global": {
+                "type": "string"
+              },
+              "qos": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "remap_target": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      ]
+    },
+    "publishers": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "message_type"],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "message_type": {
+                "type": "string",
+                "pattern": "^[^/]+/msg/[^/]+$"
+              },
+              "description": {
+                "type": "string"
+              },
+              "global": {
+                "type": "string"
+              },
+              "qos": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "remap_target": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      ]
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "message_type"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "message_type": {
+            "type": "string",
+            "pattern": "^[^/]+/(srv|action)/[^/]+$"
+          },
+          "description": {
+            "type": "string"
+          },
+          "global": {
+            "type": "string"
+          },
+          "qos": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "remap_target": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "clients": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "message_type"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "message_type": {
+            "type": "string",
+            "pattern": "^[^/]+/(srv|action)/[^/]+$"
+          },
+          "description": {
+            "type": "string"
+          },
+          "global": {
+            "type": "string"
+          },
+          "qos": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "remap_target": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "param_files": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": true
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "default": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean",
+                  "array",
+                  "object",
+                  "null"
+                ]
+              },
+              "allow_substs": {
+                "type": "boolean"
+              },
+              "schema": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      ]
+    },
+    "param_values": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": true
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "default": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean",
+                  "array",
+                  "object",
+                  "null"
+                ]
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      ]
+    },
+    "processes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "trigger_conditions", "outcomes"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "trigger_conditions": {
+            "type": "array"
+          },
+          "outcomes": {
+            "type": "array"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "if": {
+    "not": {
+      "required": ["base"]
+    }
+  },
+  "then": {
+    "required": [
+      "package",
+      "launch",
+      "subscribers",
+      "publishers",
+      "param_files",
+      "param_values",
+      "processes"
+    ]
+  }
+}

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/parameter_set.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/parameter_set.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameter Set Entity Schema 0.4.0",
+  "description": "Schema for autoware_system_design_format parameter_set entities",
+  "type": "object",
+  "required": ["name", "parameters"],
+  "properties": {
+    "autoware_system_design_format": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "remove": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "parameters": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["node"],
+        "properties": {
+          "node": {
+            "type": "string"
+          },
+          "param_files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "param_values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "local_variables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/parameter_set.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/parameter_set.json
@@ -34,6 +34,9 @@
           "node": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "param_files": {
             "type": "array",
             "items": {

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/system.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/system.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "System Entity Schema 0.4.0",
+  "description": "Schema for autoware_system_design_format system entities",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "autoware_system_design_format": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "remove": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "variables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": ["string", "number", "boolean", "array"]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "variable_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "value"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "modes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "parameter_sets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "entity"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "entity": {
+            "type": "string"
+          },
+          "compute_unit": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "parameter_set": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "arguments": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "connections": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "type": "object",
+            "minProperties": 2,
+            "maxProperties": 2,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "node_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "nodes"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "nodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "remaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "topic"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Port identifier: '{instance}.{port_type}.{port_name}' (port_type: publisher|subscriber|server|client)"
+          },
+          "topic": {
+            "type": "string",
+            "description": "Absolute ROS topic name (e.g. /api/autoware/get/engage)"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": true,
+  "if": {
+    "not": {
+      "required": ["base"]
+    }
+  },
+  "then": {
+    "required": ["components", "connections"]
+  }
+}

--- a/autoware_system_designer/autoware_system_designer/schema/0.4.0/system.json
+++ b/autoware_system_designer/autoware_system_designer/schema/0.4.0/system.json
@@ -25,6 +25,22 @@
       "type": "object",
       "additionalProperties": true
     },
+    "arguments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
     "variables": {
       "type": "array",
       "items": {
@@ -36,6 +52,9 @@
           },
           "value": {
             "type": ["string", "number", "boolean", "array"]
+          },
+          "description": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -51,6 +70,9 @@
             "type": "string"
           },
           "value": {
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           }
         },
@@ -116,6 +138,9 @@
           "arguments": {
             "type": "object",
             "additionalProperties": true
+          },
+          "description": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -179,13 +204,28 @@
           "topic": {
             "type": "string",
             "description": "Absolute ROS topic name (e.g. /api/autoware/get/engage)"
+          },
+          "description": {
+            "type": "string"
           }
         },
         "additionalProperties": false
       }
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": {
+    "description": "Mode-specific override section keyed by mode name",
+    "type": "object",
+    "properties": {
+      "override": {
+        "type": "object"
+      },
+      "remove": {
+        "type": "object"
+      }
+    },
+    "additionalProperties": false
+  },
   "if": {
     "not": {
       "required": ["base"]

--- a/autoware_system_designer/package.xml
+++ b/autoware_system_designer/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_system_designer</name>
-  <version>0.4.1</version>
+  <version>0.4.2</version>
   <description>The autoware_system_designer package</description>
 
   <maintainer email="taekjin.lee@tier4.jp">Taekjin Lee</maintainer>

--- a/autoware_system_designer/pyproject.toml
+++ b/autoware_system_designer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autoware_system_designer"
-version = "0.4.1"
+version = "0.4.2"
 description = "Autoware System Designer Package for building and deploying Autoware systems."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autoware_system_designer"
-version = "0.4.1"
+version = "0.4.2"
 dynamic = ["dependencies"]
 requires-python = ">=3.8"
 

--- a/tools/system-config-generator/pipeline/emitter/module.py
+++ b/tools/system-config-generator/pipeline/emitter/module.py
@@ -14,7 +14,7 @@ from ..launch_parser import NodeRecord
 from ..namespace_tree import NamespaceNode
 from ..port_utils import shorten_port_names
 
-DESIGN_FORMAT = "0.3.1"
+DESIGN_FORMAT = "0.4.0"
 
 
 def _build_instance_name_map(nodes: list[NodeRecord]) -> dict[str, str]:


### PR DESCRIPTION
## Description

Adds design format `0.4.0`, which introduces an optional `description` field to the design file schemas.

- New schema set `schema/0.4.0/` (`node.json`, `module.json`, `system.json`, `parameter_set.json`) with an optional `description` string on the entity itself and on its named sub-elements: node ports, servers/clients, param files/values, and processes; module instances and ports; system arguments, variables, variable files, modes, components, and remaps; parameter set node entries. Connection entries do not take a `description`.
- The system schema now lists the `arguments` field and restricts unknown root keys to mode-override sections (`{override, remove}` objects keyed by mode name), so typos like `descrition:` are caught
- `DESIGN_FORMAT_VERSION` bumped to `0.4.0`; files declaring `0.3.x` remain accepted per the minor-version compatibility rule
- The system-config-generator stamps emitted designs with `0.4.0`
- Example design files updated to `0.4.0` with top-level and sub-element descriptions; the instruction manifest documents the new field
- Package version bumped to `0.4.2`

## How to test

```bash
colcon build --packages-select autoware_system_designer
colcon test --packages-select autoware_system_designer
```

Examples in `autoware_system_design_examples/` validate against the new schemas (`pre-commit run lint-system-design-format --all-files`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
