### PR TITLE
fix: tolerate duplicate design entities unless the deployed system uses them

### DIFF
--- a/autoware_system_designer/CMakeLists.txt
+++ b/autoware_system_designer/CMakeLists.txt
@@ -17,8 +17,13 @@ install(
   USE_SOURCE_PERMISSIONS
 )
 
-# Anchor that manifest paths are written relative to; colcon lays out build/ and install/ as its siblings.
-get_filename_component(SYSTEM_DESIGN_MANIFEST_ANCHOR "${CMAKE_BINARY_DIR}/../.." ABSOLUTE)
+# Anchor that manifest paths are written relative to; when unset, colcon's default layout
+# (build/ and install/ as workspace-root siblings) supplies it.
+set(SYSTEM_DESIGN_MANIFEST_ANCHOR "" CACHE PATH
+  "Workspace root recorded as the anchor for relative design manifest paths")
+if(NOT SYSTEM_DESIGN_MANIFEST_ANCHOR)
+  get_filename_component(SYSTEM_DESIGN_MANIFEST_ANCHOR "${CMAKE_BINARY_DIR}/../.." ABSOLUTE)
+endif()
 
 # Collect system descriptions at install time.
 # ${CMAKE_CURRENT_SOURCE_DIR} and ${Python3_EXECUTABLE} are expanded at configure time;
@@ -38,6 +43,11 @@ install(CODE "
     COMMAND_ERROR_IS_FATAL ANY
   )
 ")
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(${PROJECT_NAME}_pytest test)
+endif()
 
 ament_package(
   CONFIG_EXTRAS "autoware_system_designer-extras.cmake"

--- a/autoware_system_designer/CMakeLists.txt
+++ b/autoware_system_designer/CMakeLists.txt
@@ -17,6 +17,9 @@ install(
   USE_SOURCE_PERMISSIONS
 )
 
+# Anchor that manifest paths are written relative to; colcon lays out build/ and install/ as its siblings.
+get_filename_component(SYSTEM_DESIGN_MANIFEST_ANCHOR "${CMAKE_BINARY_DIR}/../.." ABSOLUTE)
+
 # Collect system descriptions at install time.
 # ${CMAKE_CURRENT_SOURCE_DIR} and ${Python3_EXECUTABLE} are expanded at configure time;
 install(CODE "
@@ -31,6 +34,7 @@ install(CODE "
       \"${CMAKE_CURRENT_SOURCE_DIR}\"
       \"\${_dest_prefix}/share/${PROJECT_NAME}/resource\"
       \"\${CMAKE_INSTALL_PREFIX}\"
+      --anchor \"${SYSTEM_DESIGN_MANIFEST_ANCHOR}\"
     COMMAND_ERROR_IS_FATAL ANY
   )
 ")

--- a/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
@@ -14,8 +14,9 @@
 
 import copy
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Type
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type
 
 from ...exceptions import (
     FormatVersionError,
@@ -64,6 +65,85 @@ def _format_mismatch_hint(mismatch_files: list) -> str:
     )
 
 
+# Distance stand-in when no anchor is known, leaving load order to break the tie.
+_UNRANKED = 1 << 20
+
+
+def _path_distance(anchor: Path, target: Path) -> int:
+    """Number of steps between two paths, walking up to their common ancestor and back down."""
+    anchor_parts = anchor.parts
+    target_parts = target.parts
+    shared = 0
+    for left, right in zip(anchor_parts, target_parts):
+        if left != right:
+            break
+        shared += 1
+    return (len(anchor_parts) - shared) + (len(target_parts) - shared)
+
+
+@dataclass(frozen=True)
+class SelectionPolicy:
+    """Ranking inputs for picking one config among several declaring the same name."""
+
+    anchor_dir: Optional[Path] = None
+    preferred_package: Optional[str] = None
+
+    def rank(self, config: Config) -> Tuple[int, int]:
+        """Preferred package first, then proximity to the anchor; lower wins."""
+        tier = 0 if self.preferred_package and config.package == self.preferred_package else 1
+        if self.anchor_dir is None:
+            return tier, _UNRANKED
+        return tier, _path_distance(self.anchor_dir, Path(config.file_path))
+
+
+@dataclass
+class EntityGroup:
+    """Every config declaring one full_name, in load order. Selection is memoized on first use."""
+
+    full_name: str
+    name: str
+    entity_type: str
+    candidates: List[Config] = field(default_factory=list)
+    _selected: Optional[Config] = None
+
+    @property
+    def is_duplicated(self) -> bool:
+        return len(self.candidates) > 1
+
+    @property
+    def used(self) -> bool:
+        return self._selected is not None
+
+    def choose(self, policy: SelectionPolicy) -> Config:
+        """Best candidate under *policy*, load order breaking ties. Leaves the group unused."""
+        if self._selected is not None:
+            return self._selected
+        best = min(range(len(self.candidates)), key=lambda i: (policy.rank(self.candidates[i]), i))
+        return self.candidates[best]
+
+    def resolve(self, policy: SelectionPolicy) -> Tuple[Config, bool]:
+        """Select and memoize; the flag marks the first resolution, which gates reporting."""
+        if self._selected is not None:
+            return self._selected, False
+        self._selected = self.choose(policy)
+        return self._selected, True
+
+    def describe(self) -> str:
+        """Candidate list with '->' on the selection."""
+        chosen = self._selected
+        return "\n".join(
+            f"  {'->' if candidate is chosen else '  '} {candidate.file_path}"
+            + (f"  [{candidate.package}]" if candidate.package else "")
+            for candidate in self.candidates
+        )
+
+
+def format_duplicate_report(groups: List[EntityGroup]) -> str:
+    """Human-readable listing of duplicated names, '->' marking the definition in use."""
+    blocks = [f"Duplicate entity '{group.full_name}':\n{group.describe()}" for group in groups]
+    return "\n".join(blocks)
+
+
 class ConfigRegistry:
     """Collection for managing multiple entity data structures with efficient lookup methods."""
 
@@ -74,15 +154,11 @@ class ConfigRegistry:
         file_package_map: Dict[str, str] = None,
         workspace_config: List[Dict[str, Any]] = None,
         strict: bool = False,
+        anchor_dir: Optional[str] = None,
     ):
-        # Replace list with dict as primary storage
-        self.entities: Dict[str, Config] = {}  # full_name → Config
-        self._type_map: Dict[str, Dict[str, Config]] = {
-            ConfigType.NODE: {},
-            ConfigType.MODULE: {},
-            ConfigType.PARAMETER_SET: {},
-            ConfigType.SYSTEM: {},
-        }
+        # Sole entity store: full_name → every config declaring that name. A name is duplicated
+        # when its group holds more than one candidate; which one wins is decided lazily, on use.
+        self.entities: Dict[str, EntityGroup] = {}
         self.package_paths = package_paths or {}
         self.file_package_map = file_package_map or {}
         self._package_source_paths: Dict[str, Optional[str]] = {}
@@ -103,14 +179,20 @@ class ConfigRegistry:
 
         self.strict = strict
 
-        # full_name → every config declaring that name, in load order.
-        # The workspace-wide scan records collisions without failing; they are
-        # reported only when the deployed system actually uses the entity.
-        self.duplicate_entities: Dict[str, List[Config]] = {}
-        self._reported_duplicates: Set[str] = set()
+        # Anchor duplicated candidates are ranked against; assignable until the first lookup.
+        self.anchor_dir: Optional[str] = anchor_dir
 
         self.parser = ConfigParser()
         self._load_entities(config_yaml_file_paths)
+        self._log_duplicate_scan()
+
+    @property
+    def selection_policy(self) -> SelectionPolicy:
+        """Current ranking inputs for duplicated names."""
+        return SelectionPolicy(
+            anchor_dir=Path(self.anchor_dir) if self.anchor_dir else None,
+            preferred_package=self.deployment_package_name,
+        )
 
     def _load_entities(self, config_yaml_file_paths: List[str]) -> None:
         """Load entities from configuration files."""
@@ -154,20 +236,15 @@ class ConfigRegistry:
                     if resolution:
                         entity_data.package_resolution = resolution
 
-                # Record duplicates and keep the entity already registered.
-                if entity_data.full_name in self.entities:
-                    existing = self.entities[entity_data.full_name]
-                    candidates = self.duplicate_entities.setdefault(entity_data.full_name, [existing])
-                    candidates.append(entity_data)
-                    logger.info(
-                        f"Duplicate entity '{entity_data.full_name}' encountered: {entity_data.file_path} "
-                        f"(currently using {existing.file_path}; may be overridden by deployment package)"
+                group = self.entities.get(entity_data.full_name)
+                if group is None:
+                    group = EntityGroup(
+                        full_name=entity_data.full_name,
+                        name=entity_data.name,
+                        entity_type=entity_data.entity_type,
                     )
-                    continue
-
-                # Add to collections
-                self.entities[entity_data.full_name] = entity_data
-                self._type_map[entity_data.entity_type][entity_data.name] = entity_data
+                    self.entities[entity_data.full_name] = group
+                group.candidates.append(entity_data)
 
             except Exception as e:
                 src = SourceLocation(file_path=Path(file_path))
@@ -183,51 +260,39 @@ class ConfigRegistry:
 
     def get(self, name: str, default=None) -> Optional[Config]:
         """Get entity by name with default value."""
-        return self.entities.get(name, default)
+        group = self.entities.get(name)
+        return group.choose(self.selection_policy) if group else default
 
-    def resolve_duplicates(self) -> Set[str]:
-        """Repoint duplicated entities at the deployment package's copy.
+    def iter_configs(self) -> Iterator[Config]:
+        """One config per known name, without marking any group used."""
+        policy = self.selection_policy
+        for group in self.entities.values():
+            yield group.choose(policy)
 
-        Requires deployment_package_name to be final. Returns the full names whose
-        registered entity changed.
-        """
-        swapped: Set[str] = set()
-        if not self.deployment_package_name:
-            return swapped
+    def all_duplicates(self) -> List[EntityGroup]:
+        """Every duplicated name in the scan, whether the deployment reaches it or not."""
+        return [group for group in self.entities.values() if group.is_duplicated]
 
-        for full_name, candidates in self.duplicate_entities.items():
-            registered = self.entities.get(full_name)
-            preferred = next(
-                (c for c in candidates if c.package == self.deployment_package_name),
-                None,
-            )
-            if preferred is None or preferred is registered:
-                continue
-            self.entities[full_name] = preferred
-            self._type_map[preferred.entity_type][preferred.name] = preferred
-            swapped.add(full_name)
+    def used_duplicates(self) -> List[EntityGroup]:
+        """Duplicated names this deployment actually resolved."""
+        return [group for group in self.entities.values() if group.is_duplicated and group.used]
 
-        return swapped
-
-    def _check_duplicate_use(self, entity: Config) -> None:
-        """Report a duplicated entity at the point the deployed system uses it."""
-        candidates = self.duplicate_entities.get(entity.full_name)
-        if not candidates or entity.full_name in self._reported_duplicates:
+    def _log_duplicate_scan(self) -> None:
+        """Workspace-wide collision summary; the deployment-relevant subset is reported on use."""
+        duplicates = self.all_duplicates()
+        if not duplicates:
             return
-        self._reported_duplicates.add(entity.full_name)
-
-        lines = [
-            f"  {'->' if c is entity else '  '} {c.file_path}" + (f"  [{c.package}]" if c.package else "")
-            for c in candidates
-        ]
-        message = (
-            f"Duplicate entity '{entity.full_name}' is used by this deployment; "
-            f"'->' marks the definition in use:\n" + "\n".join(lines)
+        logger.debug(
+            f"{len(duplicates)} duplicated entity name(s) in the scan:\n" + format_duplicate_report(duplicates)
         )
-        src = format_source(source_from_config(entity, "/name"))
-        if self.strict:
-             raise ValidationError(f"{message}{src}")
-        logger.warning(f"{message}{src}")
+
+    def _report_duplicate(self, group: EntityGroup, chosen: Config) -> None:
+        """Surface a duplicated name at the point the deployed system first uses it."""
+        message = (
+            f"Duplicate entity '{group.full_name}' is used by this deployment; "
+            f"'->' marks the definition in use:\n{group.describe()}"
+        )
+        logger.warning(f"{message}{format_source(source_from_config(chosen, '/name'))}")
 
     def _get_entity_with_base(
         self,
@@ -240,22 +305,24 @@ class ConfigRegistry:
         """
         Generic method to get an entity and resolve base/variant if applicable.
         """
-        entity = self._type_map[config_type].get(name)
+        group = self.entities.get(f"{name}.{config_type}")
 
-        # If not found, try decoding the name (e.g. MyNode.node -> MyNode)
-        if entity is None and "." in name:
+        # If not found, the caller may already have passed a full_name (e.g. MyNode.node)
+        if group is None and "." in name:
             try:
                 decoded_name, entity_type = entity_name_decode(name)
                 if entity_type == config_type:
-                    entity = self._type_map[config_type].get(decoded_name)
+                    group = self.entities.get(f"{decoded_name}.{config_type}")
             except ValidationError:
                 pass
 
-        if entity is None:
-            available = list(self._type_map[config_type].keys())
+        if group is None:
+            available = [g.name for g in self.entities.values() if g.entity_type == config_type]
             raise error_cls(f"{config_type.capitalize()} '{name}' not found. Available {config_type}s: {available}")
 
-        self._check_duplicate_use(entity)
+        entity, first_use = group.resolve(self.selection_policy)
+        if first_use and group.is_duplicated:
+            self._report_duplicate(group, entity)
 
         if entity.sub_type == ConfigSubType.VARIANT:
             if not resolver_cls or not recursive_getter:

--- a/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
@@ -38,6 +38,7 @@ from ...parsing.config import (
 from ...parsing.loaders.data_parser import ConfigParser
 from ...parsing.loaders.data_validator import entity_name_decode
 from ...utils.format_version import check_format_version
+from ...utils.path_utils import canonical_path
 from ..resolution.variant_resolver import (
     ModuleVariantResolver,
     NodeVariantResolver,
@@ -93,7 +94,7 @@ class SelectionPolicy:
         tier = 0 if self.preferred_package and config.package == self.preferred_package else 1
         if self.anchor_dir is None:
             return tier, _UNRANKED
-        return tier, _path_distance(self.anchor_dir, Path(config.file_path))
+        return tier, _path_distance(self.anchor_dir, Path(canonical_path(str(config.file_path))))
 
 
 @dataclass
@@ -113,6 +114,11 @@ class EntityGroup:
     @property
     def used(self) -> bool:
         return self._selected is not None
+
+    @property
+    def selected(self) -> Optional[Config]:
+        """Memoized selection; None until the group is resolved."""
+        return self._selected
 
     def choose(self, policy: SelectionPolicy) -> Config:
         """Best candidate under *policy*, load order breaking ties. Leaves the group unused."""
@@ -190,7 +196,7 @@ class ConfigRegistry:
     def selection_policy(self) -> SelectionPolicy:
         """Current ranking inputs for duplicated names."""
         return SelectionPolicy(
-            anchor_dir=Path(self.anchor_dir) if self.anchor_dir else None,
+            anchor_dir=Path(canonical_path(self.anchor_dir)) if self.anchor_dir else None,
             preferred_package=self.deployment_package_name,
         )
 
@@ -258,16 +264,11 @@ class ConfigRegistry:
                     raise type(e)(f"{e}\n{hint}") from e
                 raise
 
-    def get(self, name: str, default=None) -> Optional[Config]:
-        """Get entity by name with default value."""
-        group = self.entities.get(name)
-        return group.choose(self.selection_policy) if group else default
-
-    def iter_configs(self) -> Iterator[Config]:
-        """One config per known name, without marking any group used."""
-        policy = self.selection_policy
+    def iter_used_configs(self) -> Iterator[Config]:
+        """The memoized selection of every group this deployment resolved."""
         for group in self.entities.values():
-            yield group.choose(policy)
+            if group.selected is not None:
+                yield group.selected
 
     def all_duplicates(self) -> List[EntityGroup]:
         """Every duplicated name in the scan, whether the deployment reaches it or not."""
@@ -279,11 +280,14 @@ class ConfigRegistry:
 
     def _log_duplicate_scan(self) -> None:
         """Workspace-wide collision summary; the deployment-relevant subset is reported on use."""
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
         duplicates = self.all_duplicates()
         if not duplicates:
             return
         logger.debug(
-            f"{len(duplicates)} duplicated entity name(s) in the scan:\n" + format_duplicate_report(duplicates)
+            f"{len(duplicates)} duplicated entity name(s) in the scan; candidates in load order:\n"
+            + format_duplicate_report(duplicates)
         )
 
     def _report_duplicate(self, group: EntityGroup, chosen: Config) -> None:
@@ -293,6 +297,22 @@ class ConfigRegistry:
             f"'->' marks the definition in use:\n{group.describe()}"
         )
         logger.warning(f"{message}{format_source(source_from_config(chosen, '/name'))}")
+
+    def _find_group(self, name: str, config_type: str) -> Optional[EntityGroup]:
+        """Group registered under name.config_type; the name may already carry the type suffix."""
+        group = self.entities.get(f"{name}.{config_type}")
+        if group is None and "." in name:
+            try:
+                decoded_name, entity_type = entity_name_decode(name)
+                if entity_type == config_type:
+                    group = self.entities.get(f"{decoded_name}.{config_type}")
+            except ValidationError:
+                pass
+        return group
+
+    def system_group(self, name: str) -> Optional[EntityGroup]:
+        """Candidate group for a system name; reading it leaves the group unused."""
+        return self._find_group(name, ConfigType.SYSTEM)
 
     def _get_entity_with_base(
         self,
@@ -305,16 +325,7 @@ class ConfigRegistry:
         """
         Generic method to get an entity and resolve base/variant if applicable.
         """
-        group = self.entities.get(f"{name}.{config_type}")
-
-        # If not found, the caller may already have passed a full_name (e.g. MyNode.node)
-        if group is None and "." in name:
-            try:
-                decoded_name, entity_type = entity_name_decode(name)
-                if entity_type == config_type:
-                    group = self.entities.get(f"{decoded_name}.{config_type}")
-            except ValidationError:
-                pass
+        group = self._find_group(name, config_type)
 
         if group is None:
             available = [g.name for g in self.entities.values() if g.entity_type == config_type]

--- a/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
@@ -224,9 +224,10 @@ class ConfigRegistry:
             f"Duplicate entity '{entity.full_name}' is used by this deployment; "
             f"'->' marks the definition in use:\n" + "\n".join(lines)
         )
+        src = format_source(source_from_config(entity, "/name"))
         if self.strict:
-            raise ValidationError(message)
-        logger.warning(f"{message}{format_source(source_from_config(entity, '/name'))}")
+             raise ValidationError(f"{message}{src}")
+        logger.warning(f"{message}{src}")
 
     def _get_entity_with_base(
         self,

--- a/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
@@ -160,8 +160,8 @@ class ConfigRegistry:
                     candidates = self.duplicate_entities.setdefault(entity_data.full_name, [existing])
                     candidates.append(entity_data)
                     logger.info(
-                        f"Duplicate entity '{entity_data.full_name}' ignored: {entity_data.file_path} "
-                        f"(using {existing.file_path})"
+                        f"Duplicate entity '{entity_data.full_name}' encountered: {entity_data.file_path} "
+                        f"(currently using {existing.file_path}; may be overridden by deployment package)"
                     )
                     continue
 

--- a/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
+++ b/autoware_system_designer/autoware_system_designer/building/config/config_registry.py
@@ -15,7 +15,7 @@
 import copy
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Set, Type
 
 from ...exceptions import (
     FormatVersionError,
@@ -24,7 +24,7 @@ from ...exceptions import (
     ParameterConfigurationError,
     ValidationError,
 )
-from ...file_io.source_location import SourceLocation, format_source
+from ...file_io.source_location import SourceLocation, format_source, source_from_config
 from ...parsing.config import (
     Config,
     ConfigSubType,
@@ -73,6 +73,7 @@ class ConfigRegistry:
         package_paths: Dict[str, str] = None,
         file_package_map: Dict[str, str] = None,
         workspace_config: List[Dict[str, Any]] = None,
+        strict: bool = False,
     ):
         # Replace list with dict as primary storage
         self.entities: Dict[str, Config] = {}  # full_name → Config
@@ -99,6 +100,14 @@ class ConfigRegistry:
         # Track files whose minor format version is newer than the tool supports.
         # Populated during _load_entities; surfaced to the user when the build fails.
         self.minor_version_mismatch_files: List[str] = []
+
+        self.strict = strict
+
+        # full_name → every config declaring that name, in load order.
+        # The workspace-wide scan records collisions without failing; they are
+        # reported only when the deployed system actually uses the entity.
+        self.duplicate_entities: Dict[str, List[Config]] = {}
+        self._reported_duplicates: Set[str] = set()
 
         self.parser = ConfigParser()
         self._load_entities(config_yaml_file_paths)
@@ -145,14 +154,16 @@ class ConfigRegistry:
                     if resolution:
                         entity_data.package_resolution = resolution
 
-                # Check for duplicates
+                # Record duplicates and keep the entity already registered.
                 if entity_data.full_name in self.entities:
                     existing = self.entities[entity_data.full_name]
-                    raise ValidationError(
-                        f"Duplicate entity '{entity_data.full_name}' found:\n"
-                        f"  New: {entity_data.file_path}\n"
-                        f"  Existing: {existing.file_path}"
+                    candidates = self.duplicate_entities.setdefault(entity_data.full_name, [existing])
+                    candidates.append(entity_data)
+                    logger.info(
+                        f"Duplicate entity '{entity_data.full_name}' ignored: {entity_data.file_path} "
+                        f"(using {existing.file_path})"
                     )
+                    continue
 
                 # Add to collections
                 self.entities[entity_data.full_name] = entity_data
@@ -173,6 +184,49 @@ class ConfigRegistry:
     def get(self, name: str, default=None) -> Optional[Config]:
         """Get entity by name with default value."""
         return self.entities.get(name, default)
+
+    def resolve_duplicates(self) -> Set[str]:
+        """Repoint duplicated entities at the deployment package's copy.
+
+        Requires deployment_package_name to be final. Returns the full names whose
+        registered entity changed.
+        """
+        swapped: Set[str] = set()
+        if not self.deployment_package_name:
+            return swapped
+
+        for full_name, candidates in self.duplicate_entities.items():
+            registered = self.entities.get(full_name)
+            preferred = next(
+                (c for c in candidates if c.package == self.deployment_package_name),
+                None,
+            )
+            if preferred is None or preferred is registered:
+                continue
+            self.entities[full_name] = preferred
+            self._type_map[preferred.entity_type][preferred.name] = preferred
+            swapped.add(full_name)
+
+        return swapped
+
+    def _check_duplicate_use(self, entity: Config) -> None:
+        """Report a duplicated entity at the point the deployed system uses it."""
+        candidates = self.duplicate_entities.get(entity.full_name)
+        if not candidates or entity.full_name in self._reported_duplicates:
+            return
+        self._reported_duplicates.add(entity.full_name)
+
+        lines = [
+            f"  {'->' if c is entity else '  '} {c.file_path}" + (f"  [{c.package}]" if c.package else "")
+            for c in candidates
+        ]
+        message = (
+            f"Duplicate entity '{entity.full_name}' is used by this deployment; "
+            f"'->' marks the definition in use:\n" + "\n".join(lines)
+        )
+        if self.strict:
+            raise ValidationError(message)
+        logger.warning(f"{message}{format_source(source_from_config(entity, '/name'))}")
 
     def _get_entity_with_base(
         self,
@@ -199,6 +253,8 @@ class ConfigRegistry:
         if entity is None:
             available = list(self._type_map[config_type].keys())
             raise error_cls(f"{config_type.capitalize()} '{name}' not found. Available {config_type}s: {available}")
+
+        self._check_duplicate_use(entity)
 
         if entity.sub_type == ConfigSubType.VARIANT:
             if not resolver_cls or not recursive_getter:

--- a/autoware_system_designer/autoware_system_designer/building/instances/instance_tree.py
+++ b/autoware_system_designer/autoware_system_designer/building/instances/instance_tree.py
@@ -50,8 +50,9 @@ def set_instances(
             set_module_instances(instance, entity_id, entity_name, config_registry)
         elif entity_type == "node":
             set_node_instances(instance, entity_id, entity_name, config_registry)
-    except Exception:
-        raise ValidationError(f"Error setting instances for {entity_id}, at {instance.configuration.file_path}")
+    except Exception as e:
+        location = f", at {instance.configuration.file_path}" if instance.configuration else ""
+        raise ValidationError(f"Error setting instances for {entity_id}{location}: {e}") from e
 
 
 def set_system_instances(instance: "Instance", config_registry: "ConfigRegistry") -> None:
@@ -79,12 +80,12 @@ def set_system_instances(instance: "Instance", config_registry: "ConfigRegistry"
 
         try:
             set_instances(child_instance, entity_id, config_registry)
-        except Exception:
+        except Exception as e:
             # add the instance to the children dict for debugging
             instance.children[instance_name] = child_instance
             raise ValidationError(
-                f"Error in setting component instance '{instance_name}', at {instance.configuration.file_path}"
-            )
+                f"Error in setting component instance '{instance_name}', at {instance.configuration.file_path}: {e}"
+            ) from e
 
         instance.children[instance_name] = child_instance
         logger.debug(
@@ -215,7 +216,7 @@ def create_module_children(instance: "Instance", config_registry: "ConfigRegistr
             instance.children[child_name] = child_instance
             raise ValidationError(
                 f"Error in setting child instance {child_name} : {e}, at {instance.configuration.file_path}"
-            )
+            ) from e
         instance.children[child_name] = child_instance
 
 

--- a/autoware_system_designer/autoware_system_designer/deploy.py
+++ b/autoware_system_designer/autoware_system_designer/deploy.py
@@ -43,6 +43,11 @@ from .visualization.visualize_deployment import visualize_deployment
 logger = logging.getLogger(__name__)
 
 
+def _resolve_manifest_path(path: str, anchor: str) -> str:
+    """Manifest paths are anchor-relative; absolute entries pass through unchanged."""
+    return path if os.path.isabs(path) else os.path.normpath(os.path.join(anchor, path))
+
+
 class Deployment:
     def __init__(self, deploy_config: DeploymentConfig):
         # Layer 1: YAML → Config (via ConfigRegistry)
@@ -150,6 +155,18 @@ class Deployment:
                 result.append(name)
         return result
 
+    @staticmethod
+    def _read_manifest_anchor(manifest_dir: str) -> str:
+        """Base directory for anchor-relative manifest paths; the manifest directory when unrecorded."""
+        package_map_file = os.path.join(manifest_dir, "_package_map.yaml")
+        if not os.path.isfile(package_map_file):
+            return manifest_dir
+        try:
+            return yaml_parser.load_config(package_map_file).get("workspace_root") or manifest_dir
+        except Exception as e:
+            logger.warning(f"Failed to read manifest anchor from {package_map_file}: {e}")
+            return manifest_dir
+
     def _get_system_list(self, deploy_config: DeploymentConfig) -> Tuple[List[str], Dict[str, str], Dict[str, str]]:
         system_list: list[str] = []
         package_paths: Dict[str, str] = {}
@@ -157,6 +174,8 @@ class Deployment:
         manifest_dir = deploy_config.manifest_dir
         if not os.path.isdir(manifest_dir):
             raise ValidationError(f"System design manifest directory not found or not a directory: {manifest_dir}")
+
+        anchor = self._read_manifest_anchor(manifest_dir)
 
         for entry in sorted(os.listdir(manifest_dir)):
             if not entry.endswith(".yaml"):
@@ -167,7 +186,12 @@ class Deployment:
 
                 # Load package map if available
                 if "package_map" in manifest_yaml:
-                    package_paths.update(manifest_yaml["package_map"])
+                    package_paths.update(
+                        {
+                            name: _resolve_manifest_path(path, anchor)
+                            for name, path in manifest_yaml["package_map"].items()
+                        }
+                    )
 
                 files = manifest_yaml.get("deploy_config_files")
                 # Allow the field to be empty or null without raising an error
@@ -182,6 +206,8 @@ class Deployment:
                     continue
                 for f in files:
                     file_path = f.get("path") if isinstance(f, dict) else None
+                    if file_path:
+                        file_path = _resolve_manifest_path(file_path, anchor)
                     if file_path and file_path not in system_list:
                         system_list.append(file_path)
 

--- a/autoware_system_designer/autoware_system_designer/deploy.py
+++ b/autoware_system_designer/autoware_system_designer/deploy.py
@@ -18,7 +18,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from .building.config.config_registry import ConfigRegistry
+from .building.config.config_registry import ConfigRegistry, format_duplicate_report
 from .building.deployment_instance import DeploymentInstance
 from .deployment.deploy_launchers import generate_deploy_launchers
 from .deployment.deployment_config import DeploymentConfig
@@ -68,6 +68,7 @@ class Deployment:
             file_package_map,
             workspace_config=deploy_config.workspace_config,
             strict=deploy_config.strict,
+            anchor_dir=deploy_config.anchor_dir or self._anchor_from_input(deploy_config.deployment_file),
         )
         deployment_file_abs = str(Path(deploy_config.deployment_file).resolve())
         config_registry.deployment_package_name = file_package_map.get(deployment_file_abs)
@@ -88,10 +89,10 @@ class Deployment:
             system_file_abs = str(Path(system_config.file_path).resolve())
             config_registry.deployment_package_name = file_package_map.get(system_file_abs)
 
-        # Duplicated names resolve to the deployment package's copy; re-resolve when the
-        # system entity itself was one of them.
-        if system_config.full_name in config_registry.resolve_duplicates():
-            system_config, deploy_variants, deployment_table_path = resolve_input_target(input_path, config_registry)
+        # A bare entity name gives no anchor up front; the resolved system supplies one for
+        # every lookup that follows.
+        if config_registry.anchor_dir is None:
+            config_registry.anchor_dir = str(Path(system_config.file_path).resolve().parent)
 
         logger.info(f"Resolved system file path from registry: {system_config.file_path}")
         return system_config, config_registry, deploy_variants, deployment_table_path
@@ -154,6 +155,14 @@ class Deployment:
                 seen.add(name)
                 result.append(name)
         return result
+
+    @staticmethod
+    def _anchor_from_input(input_path: str) -> Optional[str]:
+        """Directory of the deployment target; None when the target is a bare entity name."""
+        if not input_path:
+            return None
+        path = Path(input_path)
+        return str(path.resolve().parent) if path.is_file() else None
 
     @staticmethod
     def _read_manifest_anchor(manifest_dir: str) -> str:
@@ -309,6 +318,18 @@ class Deployment:
                 details_str = f" ({', '.join(details)})" if details else ""
                 raise DeploymentError(f"Error while building deploy for mode '{mode_key}'{details_str}: {e}") from e
 
+        self._check_used_duplicates()
+
+    def _check_used_duplicates(self) -> None:
+        """Strict gate on duplicated names, raised once every mode has been built and reported."""
+        duplicates = self.config_registry.used_duplicates()
+        if not duplicates or not self.config_registry.strict:
+            return
+        raise ValidationError(
+            f"{len(duplicates)} duplicated entity name(s) are used by this deployment; "
+            f"'->' marks the definition in use:\n" + format_duplicate_report(duplicates)
+        )
+
     def visualize(self):
         """Layer 3+ Consumer: Generate visualization from JSON system structure."""
         # Collect data from all deployment instances
@@ -348,7 +369,7 @@ class Deployment:
 
         package_resolution_by_name: Dict[str, str | None] = {}
         packages_without_provider: set[str] = set()
-        for entity in self.config_registry.entities.values():
+        for entity in self.config_registry.iter_configs():
             if not isinstance(entity, NodeConfig):
                 continue
             pkg_name = entity.package_name

--- a/autoware_system_designer/autoware_system_designer/deploy.py
+++ b/autoware_system_designer/autoware_system_designer/deploy.py
@@ -62,6 +62,7 @@ class Deployment:
             package_paths,
             file_package_map,
             workspace_config=deploy_config.workspace_config,
+            strict=deploy_config.strict,
         )
         deployment_file_abs = str(Path(deploy_config.deployment_file).resolve())
         config_registry.deployment_package_name = file_package_map.get(deployment_file_abs)
@@ -81,6 +82,11 @@ class Deployment:
         if config_registry.deployment_package_name is None:
             system_file_abs = str(Path(system_config.file_path).resolve())
             config_registry.deployment_package_name = file_package_map.get(system_file_abs)
+
+        # Duplicated names resolve to the deployment package's copy; re-resolve when the
+        # system entity itself was one of them.
+        if system_config.full_name in config_registry.resolve_duplicates():
+            system_config, deploy_variants, deployment_table_path = resolve_input_target(input_path, config_registry)
 
         logger.info(f"Resolved system file path from registry: {system_config.file_path}")
         return system_config, config_registry, deploy_variants, deployment_table_path

--- a/autoware_system_designer/autoware_system_designer/deploy.py
+++ b/autoware_system_designer/autoware_system_designer/deploy.py
@@ -23,7 +23,7 @@ from .building.deployment_instance import DeploymentInstance
 from .deployment.deploy_launchers import generate_deploy_launchers
 from .deployment.deployment_config import DeploymentConfig
 from .deployment.modes import apply_mode_configuration, select_modes
-from .deployment.parser import iter_mode_data, resolve_input_target
+from .deployment.parser import iter_mode_data, peek_target_system_name, resolve_input_target
 from .exceptions import DeploymentError, ValidationError
 from .exporting.instance_to_json import collect_system_structure
 from .exporting.json_io import (
@@ -37,31 +37,37 @@ from .parsing.loaders.yaml_parser import yaml_parser
 from .ros2_launcher.generate_module_launcher import generate_module_launch_file
 from .template.parameter_template_generator import ParameterTemplateGenerator
 from .utils import generate_build_scripts
+from .utils.path_utils import (
+    PACKAGE_MAP_FILENAME,
+    WORKSPACE_ROOT_KEY,
+    canonical_path,
+    resolve_manifest_path,
+)
 from .visualization.launch_commands_page import generate_launch_commands_page
 from .visualization.visualize_deployment import visualize_deployment
 
 logger = logging.getLogger(__name__)
 
 
-def _resolve_manifest_path(path: str, anchor: str) -> str:
-    """Manifest paths are anchor-relative; absolute entries pass through unchanged."""
-    return path if os.path.isabs(path) else os.path.normpath(os.path.join(anchor, path))
-
-
 class Deployment:
     def __init__(self, deploy_config: DeploymentConfig):
-        # Layer 1: YAML → Config (via ConfigRegistry)
-        system_config, self.config_registry, self.deploy_variants, self.deployment_table_path = (
-            self._layer1_yaml_to_config(deploy_config)
-        )
+        self.config_registry: Optional[ConfigRegistry] = None
+        try:
+            # Layer 1: YAML → Config (via ConfigRegistry)
+            system_config, self.deploy_variants, self.deployment_table_path = self._layer1_yaml_to_config(deploy_config)
 
-        # Layer 2+3: Config → Instance → JSON (via DeploymentInstance and serialization)
-        self._initialize_from_system_config(system_config, deploy_config)
+            # Layer 2+3: Config → Instance → JSON (via DeploymentInstance and serialization)
+            self._initialize_from_system_config(system_config, deploy_config)
+        except Exception as exc:
+            # Failure hints read the registry off the exception when construction aborts.
+            exc.config_registry = self.config_registry
+            raise
 
     def _layer1_yaml_to_config(self, deploy_config: DeploymentConfig):
         """Layer 1: Load YAML manifests and resolve system config."""
         # Load manifests and build ConfigRegistry
         system_yaml_list, package_paths, file_package_map = self._get_system_list(deploy_config)
+        self._package_paths = package_paths
         config_registry = ConfigRegistry(
             system_yaml_list,
             package_paths,
@@ -70,32 +76,53 @@ class Deployment:
             strict=deploy_config.strict,
             anchor_dir=deploy_config.anchor_dir or self._anchor_from_input(deploy_config.deployment_file),
         )
-        deployment_file_abs = str(Path(deploy_config.deployment_file).resolve())
-        config_registry.deployment_package_name = file_package_map.get(deployment_file_abs)
+        self.config_registry = config_registry
+        config_registry.deployment_package_name = file_package_map.get(canonical_path(deploy_config.deployment_file))
 
         logger.info("deployment init Deployment file: %s", deploy_config.deployment_file)
 
         # Resolve input target (could be deployment file or system-only file)
         input_path = deploy_config.deployment_file
-        deploy_variants: List[Dict[str, Any]] = []
-        deployment_table_path: Optional[str] = None
+
+        # Ranking inputs must be final before the first memoizing lookup.
+        self._finalize_selection_policy(input_path, config_registry, file_package_map)
 
         system_config, deploy_variants, deployment_table_path = resolve_input_target(input_path, config_registry)
         if not system_config:
             raise ValidationError(f"System not found from input: {input_path}")
 
-        # Fallback for deployments-table mode where deployment_file itself is not an entity file.
-        if config_registry.deployment_package_name is None:
-            system_file_abs = str(Path(system_config.file_path).resolve())
-            config_registry.deployment_package_name = file_package_map.get(system_file_abs)
-
-        # A bare entity name gives no anchor up front; the resolved system supplies one for
-        # every lookup that follows.
-        if config_registry.anchor_dir is None:
-            config_registry.anchor_dir = str(Path(system_config.file_path).resolve().parent)
-
         logger.info(f"Resolved system file path from registry: {system_config.file_path}")
-        return system_config, config_registry, deploy_variants, deployment_table_path
+        return system_config, deploy_variants, deployment_table_path
+
+    @staticmethod
+    def _finalize_selection_policy(
+        input_path: str,
+        config_registry: ConfigRegistry,
+        file_package_map: Dict[str, str],
+    ) -> None:
+        """Pin the anchor and preferred package to the target system before the first memoizing lookup."""
+        if config_registry.anchor_dir is not None and config_registry.deployment_package_name is not None:
+            return
+        try:
+            system_name = peek_target_system_name(input_path)
+        except ValidationError:
+            # resolve_input_target raises the canonical error for a broken target.
+            return
+        group = config_registry.system_group(system_name)
+        if group is None:
+            # resolve_input_target raises the canonical not-found error.
+            return
+        picked = group.choose(config_registry.selection_policy)
+        picked_path = canonical_path(str(picked.file_path))
+        if config_registry.deployment_package_name is None:
+            config_registry.deployment_package_name = file_package_map.get(picked_path) or picked.package
+        if config_registry.anchor_dir is None:
+            if group.is_duplicated:
+                logger.warning(
+                    f"Deployment target '{system_name}' is a bare entity name with duplicated definitions; "
+                    f"the anchor comes from the load-order pick:\n{group.describe()}"
+                )
+            config_registry.anchor_dir = str(Path(picked_path).parent)
 
     def _initialize_from_system_config(self, system_config: SystemConfig, deploy_config: DeploymentConfig):
         """Initialize deployment state from resolved system config."""
@@ -116,9 +143,8 @@ class Deployment:
         self.mode_keys: List[str] = []
         self.system_structure_snapshots: Dict[str, Dict[str, Any]] = {}
 
-        # Get package paths from layer 1
-        _, package_paths, _ = self._get_system_list(deploy_config)
-        self._build(system_config, package_paths)
+        # Package paths collected by layer 1.
+        self._build(system_config, self._package_paths)
 
     def _collect_deploy_variable_names(self) -> List[str]:
         variable_names: List[str] = []
@@ -162,19 +188,28 @@ class Deployment:
         if not input_path:
             return None
         path = Path(input_path)
-        return str(path.resolve().parent) if path.is_file() else None
+        return str(Path(canonical_path(input_path)).parent) if path.is_file() else None
 
     @staticmethod
     def _read_manifest_anchor(manifest_dir: str) -> str:
         """Base directory for anchor-relative manifest paths; the manifest directory when unrecorded."""
-        package_map_file = os.path.join(manifest_dir, "_package_map.yaml")
+        package_map_file = os.path.join(manifest_dir, PACKAGE_MAP_FILENAME)
         if not os.path.isfile(package_map_file):
             return manifest_dir
         try:
-            return yaml_parser.load_config(package_map_file).get("workspace_root") or manifest_dir
+            recorded = yaml_parser.load_config(package_map_file).get(WORKSPACE_ROOT_KEY)
         except Exception as e:
             logger.warning(f"Failed to read manifest anchor from {package_map_file}: {e}")
             return manifest_dir
+        if not recorded:
+            return manifest_dir
+        if not os.path.isdir(recorded):
+            logger.warning(
+                f"Recorded workspace root '{recorded}' does not exist; "
+                f"resolving relative manifest paths against {manifest_dir}"
+            )
+            return manifest_dir
+        return recorded
 
     def _get_system_list(self, deploy_config: DeploymentConfig) -> Tuple[List[str], Dict[str, str], Dict[str, str]]:
         system_list: list[str] = []
@@ -197,7 +232,7 @@ class Deployment:
                 if "package_map" in manifest_yaml:
                     package_paths.update(
                         {
-                            name: _resolve_manifest_path(path, anchor)
+                            name: resolve_manifest_path(path, anchor)
                             for name, path in manifest_yaml["package_map"].items()
                         }
                     )
@@ -216,7 +251,7 @@ class Deployment:
                 for f in files:
                     file_path = f.get("path") if isinstance(f, dict) else None
                     if file_path:
-                        file_path = _resolve_manifest_path(file_path, anchor)
+                        file_path = resolve_manifest_path(file_path, anchor)
                     if file_path and file_path not in system_list:
                         system_list.append(file_path)
 
@@ -369,7 +404,7 @@ class Deployment:
 
         package_resolution_by_name: Dict[str, str | None] = {}
         packages_without_provider: set[str] = set()
-        for entity in self.config_registry.iter_configs():
+        for entity in self.config_registry.iter_used_configs():
             if not isinstance(entity, NodeConfig):
                 continue
             pkg_name = entity.package_name

--- a/autoware_system_designer/autoware_system_designer/deployment/deployment_config.py
+++ b/autoware_system_designer/autoware_system_designer/deployment/deployment_config.py
@@ -39,6 +39,9 @@ class DeploymentConfig:
     manifest_dir: str = ""
     output_root_dir: str = "build"
     workspace_config: Optional[List[Dict[str, Any]]] = None
+    # Directory duplicated entity candidates are ranked by proximity to. None when the
+    # deployment target is a bare entity name rather than a path.
+    anchor_dir: Optional[str] = None
 
     @classmethod
     def from_env(cls) -> "DeploymentConfig":

--- a/autoware_system_designer/autoware_system_designer/deployment/deployment_config.py
+++ b/autoware_system_designer/autoware_system_designer/deployment/deployment_config.py
@@ -31,6 +31,8 @@ class DeploymentConfig:
     print_level: str = "ERROR"
     cache_enabled: bool = False
     max_cache_size: int = 128
+    # Tolerated-in-general-workspace conditions are fatal when set.
+    strict: bool = False
 
     # paths
     deployment_file: str = ""
@@ -47,6 +49,7 @@ class DeploymentConfig:
             print_level=os.getenv("AUTOWARE_SYSTEM_DESIGNER_PRINT_LEVEL", "ERROR"),
             cache_enabled=os.getenv("AUTOWARE_SYSTEM_DESIGNER_CACHE_ENABLED", "true").lower() == "true",
             max_cache_size=int(os.getenv("AUTOWARE_SYSTEM_DESIGNER_MAX_CACHE_SIZE", "128")),
+            strict=os.getenv("AUTOWARE_SYSTEM_DESIGNER_STRICT", "0").lower() in ("1", "on", "true"),
         )
 
     def set_logging(self) -> logging.Logger:

--- a/autoware_system_designer/autoware_system_designer/deployment/deployment_config.py
+++ b/autoware_system_designer/autoware_system_designer/deployment/deployment_config.py
@@ -19,6 +19,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ..utils.env import env_flag
 from ..utils.logging_utils import configure_split_stream_logging
 
 
@@ -29,7 +30,7 @@ class DeploymentConfig:
     layer_limit: int = 50
     log_level: str = "INFO"
     print_level: str = "ERROR"
-    cache_enabled: bool = False
+    cache_enabled: bool = True
     max_cache_size: int = 128
     # Tolerated-in-general-workspace conditions are fatal when set.
     strict: bool = False
@@ -39,8 +40,8 @@ class DeploymentConfig:
     manifest_dir: str = ""
     output_root_dir: str = "build"
     workspace_config: Optional[List[Dict[str, Any]]] = None
-    # Directory duplicated entity candidates are ranked by proximity to. None when the
-    # deployment target is a bare entity name rather than a path.
+    # Directory duplicated entity candidates are ranked by proximity to; None for
+    # bare-entity-name targets.
     anchor_dir: Optional[str] = None
 
     @classmethod
@@ -50,9 +51,9 @@ class DeploymentConfig:
             layer_limit=int(os.getenv("AUTOWARE_SYSTEM_DESIGNER_LAYER_LIMIT", "50")),
             log_level=os.getenv("AUTOWARE_SYSTEM_DESIGNER_LOG_LEVEL", "INFO"),
             print_level=os.getenv("AUTOWARE_SYSTEM_DESIGNER_PRINT_LEVEL", "ERROR"),
-            cache_enabled=os.getenv("AUTOWARE_SYSTEM_DESIGNER_CACHE_ENABLED", "true").lower() == "true",
+            cache_enabled=env_flag("AUTOWARE_SYSTEM_DESIGNER_CACHE_ENABLED", True),
             max_cache_size=int(os.getenv("AUTOWARE_SYSTEM_DESIGNER_MAX_CACHE_SIZE", "128")),
-            strict=os.getenv("AUTOWARE_SYSTEM_DESIGNER_STRICT", "0").lower() in ("1", "on", "true"),
+            strict=env_flag("AUTOWARE_SYSTEM_DESIGNER_STRICT", False),
         )
 
     def set_logging(self) -> logging.Logger:

--- a/autoware_system_designer/autoware_system_designer/deployment/parser.py
+++ b/autoware_system_designer/autoware_system_designer/deployment/parser.py
@@ -23,6 +23,7 @@ from ..exporting.json_io import extract_system_structure_data, load_system_struc
 from ..parsing.config import SystemConfig
 from ..parsing.loaders.data_validator import entity_name_decode
 from ..parsing.loaders.yaml_parser import yaml_parser
+from ..utils.path_utils import canonical_path
 
 
 def iter_mode_data(
@@ -54,7 +55,7 @@ def _resolve_deployments_path(input_path: str) -> str:
         candidate = Path(f"{input_path}.yaml")
 
     if candidate.exists() and candidate.is_file():
-        return str(candidate.resolve())
+        return canonical_path(str(candidate))
 
     raise ValidationError(
         f"Deployments table file not found: {candidate}. "
@@ -94,6 +95,15 @@ def _parse_deployments_list(deployments_path: str) -> Tuple[str, List[Dict[str, 
         deploy_list.append({"name": name, "arguments": arguments})
 
     return base, deploy_list
+
+
+def peek_target_system_name(input_path: str) -> str:
+    """System entity name the build target designates."""
+    if input_path.endswith(".deployments") or input_path.endswith(".deployments.yaml"):
+        table_path = _resolve_deployments_path(input_path)
+        base_name, _ = _parse_deployments_list(table_path)
+        return _normalize_system_name(base_name)
+    return _normalize_system_name(input_path)
 
 
 def resolve_input_target(

--- a/autoware_system_designer/autoware_system_designer/utils/env.py
+++ b/autoware_system_designer/autoware_system_designer/utils/env.py
@@ -1,0 +1,28 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment variable parsing shared across the package."""
+
+import os
+
+# Accepted set is mirrored by the stdlib-only script/system_designer_runner.py.
+_TRUTHY_VALUES = {"1", "true", "on", "yes", "y"}
+
+
+def env_flag(name: str, default: bool) -> bool:
+    """Boolean environment variable; any value outside 1/true/on/yes/y (case-insensitive) is false."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in _TRUTHY_VALUES

--- a/autoware_system_designer/autoware_system_designer/utils/path_utils.py
+++ b/autoware_system_designer/autoware_system_designer/utils/path_utils.py
@@ -1,0 +1,33 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical path namespace shared by manifest readers, file maps, and duplicate ranking."""
+
+import os
+from functools import lru_cache
+
+# Manifest recording the workspace package map and the anchor for relative entries.
+PACKAGE_MAP_FILENAME = "_package_map.yaml"
+WORKSPACE_ROOT_KEY = "workspace_root"
+
+
+@lru_cache(maxsize=None)
+def canonical_path(path: str) -> str:
+    """Absolute path with symlinks resolved; the single key namespace for file lookups and ranking."""
+    return os.path.realpath(path)
+
+
+def resolve_manifest_path(path: str, anchor: str) -> str:
+    """Canonical absolute path of a manifest entry; relative entries are joined to the anchor."""
+    return canonical_path(path if os.path.isabs(path) else os.path.join(anchor, path))

--- a/autoware_system_designer/package.xml
+++ b/autoware_system_designer/package.xml
@@ -18,6 +18,9 @@
 
   <exec_depend>ament_index_python</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/autoware_system_designer/script/collect_system_design_manifests.py
+++ b/autoware_system_designer/script/collect_system_design_manifests.py
@@ -26,7 +26,7 @@ def find_packages(root_dir):
         if "package.xml" in filenames:
             name = get_package_name(dirpath)
             if name:
-                packages[os.path.abspath(dirpath)] = name
+                packages[os.path.realpath(dirpath)] = name
             # Optimization: don't traverse inside packages unless they are metapackages?
             # ROS 2 packages usually don't nest.
             # But let's be safe and traverse.
@@ -64,8 +64,20 @@ def is_target_design_file(filename):
 
 
 def to_manifest_path(path, anchor):
-    """Manifest paths are anchor-relative when an anchor is set, absolute otherwise."""
-    return os.path.relpath(path, anchor) if anchor else path
+    """Manifest entry for a path: anchor-relative when inside the anchor, absolute otherwise.
+
+    Inverse of autoware_system_designer.utils.path_utils.resolve_manifest_path; kept local so
+    the collector runs stdlib-only at install time.
+    """
+    if not anchor:
+        return path
+    try:
+        rel = os.path.relpath(path, anchor)
+    except ValueError:
+        return path
+    if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+        return path
+    return rel
 
 
 def find_source_root(start_path):
@@ -130,7 +142,7 @@ def main():
     )
     args = parser.parse_args()
 
-    anchor = os.path.abspath(args.anchor) if args.anchor else None
+    anchor = os.path.realpath(args.anchor) if args.anchor else None
 
     # Find workspace root
     workspace_root = find_source_root(args.start_path)
@@ -166,7 +178,7 @@ def main():
     yaml_parse_errors = []
 
     for yaml_file in yaml_files:
-        yaml_file_abs = os.path.abspath(yaml_file)
+        yaml_file_abs = os.path.realpath(yaml_file)
 
         if not is_target_design_file(os.path.basename(yaml_file_abs)):
             continue

--- a/autoware_system_designer/script/collect_system_design_manifests.py
+++ b/autoware_system_designer/script/collect_system_design_manifests.py
@@ -35,8 +35,8 @@ def find_packages(root_dir):
 
 def parse_design_file(filepath):
     try:
-        with open(filepath, "r") as f:
-            content = yaml.safe_load(f)
+        with open(filepath, "r") as file:
+            content = yaml.safe_load(file)
     except (yaml.YAMLError, UnicodeDecodeError) as exc:
         raise ValueError(f"Failed to parse YAML file: {filepath}") from exc
     except OSError as exc:
@@ -165,23 +165,23 @@ def main():
 
     yaml_parse_errors = []
 
-    for yf in yaml_files:
-        yf_abs = os.path.abspath(yf)
+    for yaml_file in yaml_files:
+        yaml_file_abs = os.path.abspath(yaml_file)
 
-        if not is_target_design_file(os.path.basename(yf_abs)):
+        if not is_target_design_file(os.path.basename(yaml_file_abs)):
             continue
 
         # Check content first (it's a hard requirement)
         try:
-            content = parse_design_file(yf_abs)
+            content = parse_design_file(yaml_file_abs)
         except ValueError:
-            yaml_parse_errors.append(yf_abs)
+            yaml_parse_errors.append(yaml_file_abs)
             continue
         if not content:
             continue
 
         # Find which package it belongs to
-        parent = os.path.dirname(yf_abs)
+        parent = os.path.dirname(yaml_file_abs)
         found_pkg = None
 
         # Traverse up
@@ -206,7 +206,7 @@ def main():
 
         if target_pkg not in pkg_files:
             pkg_files[target_pkg] = []
-        pkg_files[target_pkg].append(yf_abs)
+        pkg_files[target_pkg].append(yaml_file_abs)
 
     if yaml_parse_errors:
         unique_files = sorted(set(yaml_parse_errors))
@@ -223,21 +223,21 @@ def main():
     package_map = {}
     for pkg_src_path, pkg_name in pkg_paths.items():
         if is_source_mode:
-            p = pkg_src_path
+            pkg_path = pkg_src_path
         elif is_isolated:
             # isolated: install_base/pkg_name/share/pkg_name
-            p = os.path.join(install_base, pkg_name, "share", pkg_name)
+            pkg_path = os.path.join(install_base, pkg_name, "share", pkg_name)
         else:
             # merged: install_prefix/share/pkg_name
-            p = os.path.join(args.install_prefix, "share", pkg_name)
-        package_map[pkg_name] = to_manifest_path(p, anchor)
+            pkg_path = os.path.join(args.install_prefix, "share", pkg_name)
+        package_map[pkg_name] = to_manifest_path(pkg_path, anchor)
 
     package_map_path = os.path.join(output_dir, "_package_map.yaml")
     package_map_data = {"package_map": package_map}
     if anchor:
         package_map_data["workspace_root"] = anchor
-    with open(package_map_path, "w") as f:
-        yaml.dump(package_map_data, f)
+    with open(package_map_path, "w") as manifest_file:
+        yaml.dump(package_map_data, manifest_file)
         print(f"Generated {package_map_path} with {len(package_map)} packages")
 
     # 2. Generate individual manifests for packages with design files
@@ -252,14 +252,14 @@ def main():
 
         data = {"package_name": pkg, "deploy_config_files": []}
 
-        for f in files:
-            t = infer_type(os.path.basename(f))
-            if t == "unknown":
+        for design_file in files:
+            design_type = infer_type(os.path.basename(design_file))
+            if design_type == "unknown":
                 continue
-            data["deploy_config_files"].append({"path": to_manifest_path(f, anchor), "type": t})
+            data["deploy_config_files"].append({"path": to_manifest_path(design_file, anchor), "type": design_type})
 
-        with open(manifest_path, "w") as f:
-            yaml.dump(data, f)
+        with open(manifest_path, "w") as manifest_file:
+            yaml.dump(data, manifest_file)
             print(f"Generated {manifest_path}")
 
 

--- a/autoware_system_designer/script/collect_system_design_manifests.py
+++ b/autoware_system_designer/script/collect_system_design_manifests.py
@@ -63,6 +63,11 @@ def is_target_design_file(filename):
     return infer_type(filename) != "unknown"
 
 
+def to_manifest_path(path, anchor):
+    """Manifest paths are anchor-relative when an anchor is set, absolute otherwise."""
+    return os.path.relpath(path, anchor) if anchor else path
+
+
 def find_source_root(start_path):
     """
     Find the workspace source root directory by traversing up from start_path.
@@ -115,7 +120,17 @@ def main():
             "'source' uses workspace source package directories (CI/no-build mode)."
         ),
     )
+    parser.add_argument(
+        "--anchor",
+        default=None,
+        help=(
+            "Base directory that manifest paths are written relative to, recorded as "
+            "'workspace_root' in _package_map.yaml. Absolute paths are written when omitted."
+        ),
+    )
     args = parser.parse_args()
+
+    anchor = os.path.abspath(args.anchor) if args.anchor else None
 
     # Find workspace root
     workspace_root = find_source_root(args.start_path)
@@ -215,11 +230,14 @@ def main():
         else:
             # merged: install_prefix/share/pkg_name
             p = os.path.join(args.install_prefix, "share", pkg_name)
-        package_map[pkg_name] = p
+        package_map[pkg_name] = to_manifest_path(p, anchor)
 
     package_map_path = os.path.join(output_dir, "_package_map.yaml")
+    package_map_data = {"package_map": package_map}
+    if anchor:
+        package_map_data["workspace_root"] = anchor
     with open(package_map_path, "w") as f:
-        yaml.dump({"package_map": package_map}, f)
+        yaml.dump(package_map_data, f)
         print(f"Generated {package_map_path} with {len(package_map)} packages")
 
     # 2. Generate individual manifests for packages with design files
@@ -238,7 +256,7 @@ def main():
             t = infer_type(os.path.basename(f))
             if t == "unknown":
                 continue
-            data["deploy_config_files"].append({"path": f, "type": t})
+            data["deploy_config_files"].append({"path": to_manifest_path(f, anchor), "type": t})
 
         with open(manifest_path, "w") as f:
             yaml.dump(data, f)

--- a/autoware_system_designer/script/deployment_process.py
+++ b/autoware_system_designer/script/deployment_process.py
@@ -92,20 +92,25 @@ def build(deployment_file: str, manifest_dir: str, output_root_dir: str, workspa
         update_index(output_root_dir)
 
         logger.info("Autoware System Designer: Done!")
-    except Exception:
-        # Surface minor-version mismatch warnings when the build fails.
-        # The Deployment / ConfigRegistry layers may have already appended
-        # the hint to the exception message, but if the failure happened
-        # before a Deployment was fully constructed we still have the
-        # registry to check.
-        _emit_minor_version_hint(deployment)
-        _emit_duplicate_hint(deployment)
+    except Exception as exc:
+        # Construction failures carry the registry on the exception; hints
+        # surface duplicate and minor-version context alongside the error.
+        _emit_minor_version_hint(deployment, exc)
+        _emit_duplicate_hint(deployment, exc)
         raise
 
 
-def _emit_duplicate_hint(deployment):
+def _find_registry(deployment, exc):
+    """Registry attached to the exception, or the deployment's when construction completed."""
+    registry = getattr(exc, "config_registry", None)
+    if registry is not None:
+        return registry
+    return getattr(deployment, "config_registry", None) if deployment else None
+
+
+def _emit_duplicate_hint(deployment, exc):
     """Log the duplicated names the deployment reached, if any."""
-    registry = getattr(deployment, "config_registry", None) if deployment else None
+    registry = _find_registry(deployment, exc)
     if registry is None:
         return
     duplicates = registry.used_duplicates()
@@ -113,17 +118,15 @@ def _emit_duplicate_hint(deployment):
         return
     from autoware_system_designer.building.config.config_registry import format_duplicate_report
 
-    _logger.warning(
+    _logger.error(
         f"Note: {len(duplicates)} duplicated entity name(s) are used by this deployment. "
         f"This may have contributed to the error:\n" + format_duplicate_report(duplicates)
     )
 
 
-def _emit_minor_version_hint(deployment):
+def _emit_minor_version_hint(deployment, exc):
     """Log minor-version mismatch files if any were recorded."""
-    if deployment is None:
-        return
-    registry = getattr(deployment, "config_registry", None)
+    registry = _find_registry(deployment, exc)
     if registry is None:
         return
     files = getattr(registry, "minor_version_mismatch_files", [])
@@ -131,7 +134,7 @@ def _emit_minor_version_hint(deployment):
         return
     from autoware_system_designer.building.config.config_registry import _format_mismatch_hint
 
-    _logger.warning(_format_mismatch_hint(files))
+    _logger.error(_format_mismatch_hint(files))
 
 
 if __name__ == "__main__":

--- a/autoware_system_designer/script/deployment_process.py
+++ b/autoware_system_designer/script/deployment_process.py
@@ -99,7 +99,24 @@ def build(deployment_file: str, manifest_dir: str, output_root_dir: str, workspa
         # before a Deployment was fully constructed we still have the
         # registry to check.
         _emit_minor_version_hint(deployment)
+        _emit_duplicate_hint(deployment)
         raise
+
+
+def _emit_duplicate_hint(deployment):
+    """Log the duplicated names the deployment reached, if any."""
+    registry = getattr(deployment, "config_registry", None) if deployment else None
+    if registry is None:
+        return
+    duplicates = registry.used_duplicates()
+    if not duplicates:
+        return
+    from autoware_system_designer.building.config.config_registry import format_duplicate_report
+
+    _logger.warning(
+        f"Note: {len(duplicates)} duplicated entity name(s) are used by this deployment. "
+        f"This may have contributed to the error:\n" + format_duplicate_report(duplicates)
+    )
 
 
 def _emit_minor_version_hint(deployment):

--- a/autoware_system_designer/script/deployment_process.py
+++ b/autoware_system_designer/script/deployment_process.py
@@ -112,7 +112,7 @@ def _emit_minor_version_hint(deployment):
     files = getattr(registry, "minor_version_mismatch_files", [])
     if not files:
         return
-    from autoware_system_designer.builder.config.config_registry import _format_mismatch_hint
+    from autoware_system_designer.building.config.config_registry import _format_mismatch_hint
 
     _logger.warning(_format_mismatch_hint(files))
 

--- a/autoware_system_designer/script/system_designer_runner.py
+++ b/autoware_system_designer/script/system_designer_runner.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import List
 
 
+# Accepted set matches autoware_system_designer.utils.env.env_flag; this wrapper stays stdlib-only.
 def _truthy(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "on", "yes", "y"}
 

--- a/autoware_system_designer/script/system_designer_runner.py
+++ b/autoware_system_designer/script/system_designer_runner.py
@@ -214,6 +214,7 @@ def main(argv: List[str]) -> int:
 
     env = os.environ.copy()
     env["AUTOWARE_SYSTEM_DESIGNER_PRINT_LEVEL"] = args.print_level
+    env["AUTOWARE_SYSTEM_DESIGNER_STRICT"] = "1" if strict else "0"
     env.setdefault("PYTHONUNBUFFERED", "1")
 
     command = [

--- a/autoware_system_designer/test/conftest.py
+++ b/autoware_system_designer/test/conftest.py
@@ -1,0 +1,96 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+NODE_TEMPLATE = """\
+autoware_system_design_format: 0.3.0
+
+name: {name}.node
+
+package:
+  name: {package}
+  provider: dummy
+
+launch:
+  plugin: dummy::{name}
+
+subscribers: []
+publishers: []
+param_files: []
+param_values: []
+processes: []
+"""
+
+SYSTEM_TEMPLATE = """\
+autoware_system_design_format: 0.3.0
+
+name: {name}.system
+
+modes:
+  - name: default
+    description: Default mode
+    default: true
+
+components:
+  - name: demo
+    entity: {node}.node
+    compute_unit: main_ecu
+
+connections: []
+"""
+
+
+def write_node(pkg_dir: Path, name: str, package: str) -> Path:
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    path = pkg_dir / f"{name}.node.yaml"
+    path.write_text(NODE_TEMPLATE.format(name=name, package=package))
+    return path
+
+
+def write_system(pkg_dir: Path, name: str, node: str) -> Path:
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    path = pkg_dir / f"{name}.system.yaml"
+    path.write_text(SYSTEM_TEMPLATE.format(name=name, node=node))
+    return path
+
+
+@pytest.fixture
+def duplicate_workspace(tmp_path):
+    """Two packages declaring the same node name; pkg_a also declares the system."""
+    pkg_a = tmp_path / "pkg_a"
+    pkg_b = tmp_path / "pkg_b"
+    files = {
+        "node_a": write_node(pkg_a, "Demo", "pkg_a"),
+        "node_b": write_node(pkg_b, "Demo", "pkg_b"),
+        "system_a": write_system(pkg_a, "Tiny", "Demo"),
+    }
+    file_package_map = {
+        str(files["node_a"]): "pkg_a",
+        str(files["node_b"]): "pkg_b",
+        str(files["system_a"]): "pkg_a",
+    }
+    return {
+        "root": tmp_path,
+        "pkg_a": pkg_a,
+        "pkg_b": pkg_b,
+        "files": files,
+        "file_paths": [str(path) for path in files.values()],
+        "file_package_map": file_package_map,
+    }

--- a/autoware_system_designer/test/test_entity_group.py
+++ b/autoware_system_designer/test/test_entity_group.py
@@ -1,0 +1,63 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from autoware_system_designer.building.config.config_registry import (
+    EntityGroup,
+    SelectionPolicy,
+    format_duplicate_report,
+)
+
+
+def _group():
+    return EntityGroup(
+        full_name="Demo.node",
+        name="Demo",
+        entity_type="node",
+        candidates=[
+            SimpleNamespace(file_path=Path("/ws/pkg_a/x.yaml"), package="pkg_a"),
+            SimpleNamespace(file_path=Path("/ws/pkg_b/x.yaml"), package="pkg_b"),
+        ],
+    )
+
+
+def test_choose_does_not_memoize_or_mark_used():
+    group = _group()
+    group.choose(SelectionPolicy())
+    assert not group.used
+    assert group.selected is None
+    picked = group.choose(SelectionPolicy(anchor_dir=Path("/ws/pkg_b")))
+    assert str(picked.file_path) == "/ws/pkg_b/x.yaml"
+
+
+def test_resolve_memoizes_and_flags_first_use_once():
+    group = _group()
+    first, first_use = group.resolve(SelectionPolicy())
+    assert first_use and group.used
+    again, first_use = group.resolve(SelectionPolicy(anchor_dir=Path("/ws/pkg_b")))
+    assert not first_use
+    assert again is first
+    assert group.choose(SelectionPolicy(anchor_dir=Path("/ws/pkg_b"))) is first
+
+
+def test_describe_marks_only_the_memoized_selection():
+    group = _group()
+    assert "->" not in group.describe()
+    group.resolve(SelectionPolicy())
+    report = format_duplicate_report([group])
+    marked = [line for line in report.splitlines() if line.lstrip().startswith("->")]
+    assert len(marked) == 1
+    assert "pkg_a" in marked[0]

--- a/autoware_system_designer/test/test_env_flags.py
+++ b/autoware_system_designer/test/test_env_flags.py
@@ -1,0 +1,37 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from autoware_system_designer.utils.env import env_flag
+
+VAR = "AUTOWARE_SYSTEM_DESIGNER_TEST_FLAG"
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "on", "yes", "y", " Yes "])
+def test_truthy_values(monkeypatch, value):
+    monkeypatch.setenv(VAR, value)
+    assert env_flag(VAR, False) is True
+
+
+@pytest.mark.parametrize("value", ["0", "off", "false", "no", "", "enable"])
+def test_falsy_values(monkeypatch, value):
+    monkeypatch.setenv(VAR, value)
+    assert env_flag(VAR, True) is False
+
+
+def test_unset_returns_default(monkeypatch):
+    monkeypatch.delenv(VAR, raising=False)
+    assert env_flag(VAR, True) is True
+    assert env_flag(VAR, False) is False

--- a/autoware_system_designer/test/test_failure_hints.py
+++ b/autoware_system_designer/test/test_failure_hints.py
@@ -1,0 +1,70 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from conftest import write_node, write_system
+
+from autoware_system_designer.deploy import Deployment
+from autoware_system_designer.deployment.deployment_config import DeploymentConfig
+
+_PROCESS_PATH = Path(__file__).resolve().parents[1] / "script" / "deployment_process.py"
+_spec = importlib.util.spec_from_file_location("deployment_process", _PROCESS_PATH)
+deployment_process = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deployment_process)
+
+
+def test_construction_failure_carries_registry_on_exception(tmp_path):
+    pkg_a = tmp_path / "pkg_a"
+    system_file = write_system(pkg_a, "Broken", "Missing")
+    node_file = write_node(pkg_a, "Demo", "pkg_a")
+    manifest_dir = tmp_path / "resource"
+    manifest_dir.mkdir()
+    (manifest_dir / "pkg_a.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "package_name": "pkg_a",
+                "deploy_config_files": [
+                    {"path": str(system_file), "type": "system"},
+                    {"path": str(node_file), "type": "node"},
+                ],
+            }
+        )
+    )
+
+    config = DeploymentConfig()
+    config.deployment_file = "Broken.system"
+    config.manifest_dir = str(manifest_dir)
+    config.output_root_dir = str(tmp_path / "out")
+
+    with pytest.raises(Exception) as excinfo:
+        Deployment(config)
+    assert getattr(excinfo.value, "config_registry", None) is not None
+
+
+def test_find_registry_prefers_the_exception_attachment():
+    exc = RuntimeError("boom")
+    exc.config_registry = "registry-from-exception"
+    assert deployment_process._find_registry(None, exc) == "registry-from-exception"
+
+
+def test_find_registry_falls_back_to_the_deployment():
+    exc = RuntimeError("boom")
+    deployment = SimpleNamespace(config_registry="registry-from-deployment")
+    assert deployment_process._find_registry(deployment, exc) == "registry-from-deployment"
+    assert deployment_process._find_registry(None, exc) is None

--- a/autoware_system_designer/test/test_path_utils.py
+++ b/autoware_system_designer/test/test_path_utils.py
@@ -1,0 +1,93 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import os
+from pathlib import Path
+
+import yaml
+
+from autoware_system_designer.deploy import Deployment
+from autoware_system_designer.utils.path_utils import canonical_path, resolve_manifest_path
+
+_COLLECTOR_PATH = Path(__file__).resolve().parents[1] / "script" / "collect_system_design_manifests.py"
+_spec = importlib.util.spec_from_file_location("collect_system_design_manifests", _COLLECTOR_PATH)
+collector = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(collector)
+
+
+def test_canonical_path_unifies_symlinked_paths(tmp_path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    (real_dir / "x.yaml").write_text("")
+    link = tmp_path / "link"
+    link.symlink_to(real_dir)
+    assert canonical_path(str(link / "x.yaml")) == canonical_path(str(real_dir / "x.yaml"))
+
+
+def test_resolve_manifest_path_joins_relative_entries(tmp_path):
+    resolved = resolve_manifest_path(os.path.join("pkg_a", "x.yaml"), str(tmp_path))
+    assert resolved == canonical_path(str(tmp_path / "pkg_a" / "x.yaml"))
+
+
+def test_resolve_manifest_path_keeps_absolute_entries(tmp_path):
+    target = tmp_path / "pkg_a" / "x.yaml"
+    assert resolve_manifest_path(str(target), "/elsewhere") == canonical_path(str(target))
+
+
+def test_to_manifest_path_relativizes_inside_anchor(tmp_path):
+    target = tmp_path / "pkg_a" / "x.yaml"
+    assert collector.to_manifest_path(str(target), str(tmp_path)) == os.path.join("pkg_a", "x.yaml")
+
+
+def test_to_manifest_path_keeps_paths_outside_anchor_absolute(tmp_path):
+    outside = "/opt/elsewhere/x.yaml"
+    assert collector.to_manifest_path(outside, str(tmp_path)) == outside
+
+
+def test_to_manifest_path_without_anchor_is_identity():
+    assert collector.to_manifest_path("/ws/pkg_a/x.yaml", None) == "/ws/pkg_a/x.yaml"
+
+
+def test_manifest_round_trip(tmp_path):
+    target = tmp_path / "pkg_a" / "x.yaml"
+    entry = collector.to_manifest_path(str(target), str(tmp_path))
+    assert resolve_manifest_path(entry, str(tmp_path)) == canonical_path(str(target))
+
+
+def _write_package_map(manifest_dir: Path, workspace_root):
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"package_map": {}}
+    if workspace_root is not None:
+        payload["workspace_root"] = workspace_root
+    (manifest_dir / "_package_map.yaml").write_text(yaml.safe_dump(payload))
+
+
+def test_read_manifest_anchor_returns_recorded_root(tmp_path):
+    manifest_dir = tmp_path / "resource"
+    _write_package_map(manifest_dir, str(tmp_path))
+    assert Deployment._read_manifest_anchor(str(manifest_dir)) == str(tmp_path)
+
+
+def test_read_manifest_anchor_falls_back_when_root_is_stale(tmp_path):
+    manifest_dir = tmp_path / "resource"
+    _write_package_map(manifest_dir, "/nonexistent/build/machine/ws")
+    assert Deployment._read_manifest_anchor(str(manifest_dir)) == str(manifest_dir)
+
+
+def test_read_manifest_anchor_falls_back_when_unrecorded(tmp_path):
+    manifest_dir = tmp_path / "resource"
+    _write_package_map(manifest_dir, None)
+    assert Deployment._read_manifest_anchor(str(manifest_dir)) == str(manifest_dir)
+    assert Deployment._read_manifest_anchor(str(tmp_path / "missing")) == str(tmp_path / "missing")

--- a/autoware_system_designer/test/test_registry_selection.py
+++ b/autoware_system_designer/test/test_registry_selection.py
@@ -1,0 +1,82 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from autoware_system_designer.building.config.config_registry import ConfigRegistry
+from autoware_system_designer.deploy import Deployment
+
+
+def _registry(workspace, anchor_dir=None):
+    return ConfigRegistry(
+        workspace["file_paths"],
+        file_package_map=workspace["file_package_map"],
+        anchor_dir=anchor_dir,
+    )
+
+
+def test_anchor_proximity_selects_the_near_candidate(duplicate_workspace):
+    registry = _registry(duplicate_workspace, anchor_dir=str(duplicate_workspace["pkg_b"]))
+    node = registry.get_node("Demo")
+    assert str(node.file_path) == str(duplicate_workspace["files"]["node_b"])
+
+
+def test_preferred_package_beats_proximity(duplicate_workspace):
+    registry = _registry(duplicate_workspace, anchor_dir=str(duplicate_workspace["pkg_b"]))
+    registry.deployment_package_name = "pkg_a"
+    node = registry.get_node("Demo")
+    assert str(node.file_path) == str(duplicate_workspace["files"]["node_a"])
+
+
+def test_symlinked_anchor_ranks_against_real_candidate_paths(duplicate_workspace):
+    link = duplicate_workspace["root"] / "ws_link"
+    link.symlink_to(duplicate_workspace["root"])
+    registry = _registry(duplicate_workspace, anchor_dir=str(link / "pkg_b"))
+    node = registry.get_node("Demo")
+    assert str(node.file_path) == str(duplicate_workspace["files"]["node_b"])
+
+
+def test_iter_used_configs_yields_only_resolved_selections(duplicate_workspace):
+    registry = _registry(duplicate_workspace, anchor_dir=str(duplicate_workspace["pkg_b"]))
+    assert list(registry.iter_used_configs()) == []
+    node_group = registry.entities["Demo.node"]
+    node_group.choose(registry.selection_policy)
+    assert list(registry.iter_used_configs()) == []
+    registry.get_node("Demo")
+    used = list(registry.iter_used_configs())
+    assert [str(config.file_path) for config in used] == [str(duplicate_workspace["files"]["node_b"])]
+    assert not registry.system_group("Tiny").used
+
+
+def test_system_group_accepts_short_and_full_names(duplicate_workspace):
+    registry = _registry(duplicate_workspace)
+    assert registry.system_group("Tiny") is registry.system_group("Tiny.system")
+    assert registry.system_group("Missing") is None
+
+
+def test_finalize_selection_policy_pins_anchor_and_package_for_bare_names(duplicate_workspace):
+    registry = _registry(duplicate_workspace)
+    assert registry.anchor_dir is None
+    Deployment._finalize_selection_policy("Tiny.system", registry, duplicate_workspace["file_package_map"])
+    assert registry.anchor_dir == str(Path(str(duplicate_workspace["files"]["system_a"])).parent)
+    assert registry.deployment_package_name == "pkg_a"
+    node = registry.get_node("Demo")
+    assert str(node.file_path) == str(duplicate_workspace["files"]["node_a"])
+
+
+def test_finalize_selection_policy_leaves_unknown_targets_untouched(duplicate_workspace):
+    registry = _registry(duplicate_workspace)
+    Deployment._finalize_selection_policy("Missing.system", registry, duplicate_workspace["file_package_map"])
+    assert registry.anchor_dir is None
+    assert registry.deployment_package_name is None

--- a/autoware_system_designer/test/test_selection_policy.py
+++ b/autoware_system_designer/test/test_selection_policy.py
@@ -1,0 +1,63 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from autoware_system_designer.building.config.config_registry import (
+    _UNRANKED,
+    EntityGroup,
+    SelectionPolicy,
+    _path_distance,
+)
+
+
+def _config(file_path: str, package: str = None):
+    return SimpleNamespace(file_path=Path(file_path), package=package)
+
+
+def test_path_distance_counts_steps_over_common_ancestor():
+    assert _path_distance(Path("/ws/pkg_a"), Path("/ws/pkg_a/design.yaml")) == 1
+    assert _path_distance(Path("/ws/pkg_a"), Path("/ws/pkg_b/design.yaml")) == 3
+    assert _path_distance(Path("/ws"), Path("/ws")) == 0
+
+
+def test_rank_without_anchor_is_unranked():
+    policy = SelectionPolicy(anchor_dir=None, preferred_package=None)
+    assert policy.rank(_config("/ws/pkg_a/x.yaml")) == (1, _UNRANKED)
+
+
+def test_rank_prefers_deployment_package_over_proximity():
+    policy = SelectionPolicy(anchor_dir=Path("/ws/pkg_b"), preferred_package="pkg_a")
+    near = policy.rank(_config("/ws/pkg_b/x.yaml", package="pkg_b"))
+    far_preferred = policy.rank(_config("/ws/pkg_a/x.yaml", package="pkg_a"))
+    assert far_preferred < near
+
+
+def test_rank_uses_anchor_proximity_within_a_tier():
+    policy = SelectionPolicy(anchor_dir=Path("/ws/pkg_b"), preferred_package=None)
+    near = policy.rank(_config("/ws/pkg_b/x.yaml"))
+    far = policy.rank(_config("/ws/pkg_a/x.yaml"))
+    assert near < far
+
+
+def test_choose_breaks_ties_by_load_order():
+    group = EntityGroup(
+        full_name="Demo.node",
+        name="Demo",
+        entity_type="node",
+        candidates=[_config("/ws/pkg_a/x.yaml"), _config("/ws/pkg_b/x.yaml")],
+    )
+    picked = group.choose(SelectionPolicy())
+    assert str(picked.file_path) == "/ws/pkg_a/x.yaml"

--- a/tools/system-config-generator/pipeline/emitter/node.py
+++ b/tools/system-config-generator/pipeline/emitter/node.py
@@ -34,7 +34,11 @@ def load_package_map(path: Path) -> dict[str, str]:
 
 
 def _resolve(share: str, anchor: Path) -> str:
-    """Manifest paths are anchor-relative; absolute entries pass through unchanged."""
+    """Manifest paths are anchor-relative; absolute entries pass through unchanged.
+
+    Standalone mirror of autoware_system_designer.utils.path_utils.resolve_manifest_path;
+    this tool imports no designer package code.
+    """
     p = Path(share)
     return share if p.is_absolute() else os.path.normpath(anchor / p)
 

--- a/tools/system-config-generator/pipeline/emitter/node.py
+++ b/tools/system-config-generator/pipeline/emitter/node.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -28,7 +29,14 @@ def load_package_map(path: Path) -> dict[str, str]:
         return {}
     with open(path) as f:
         data = yaml.safe_load(f) or {}
-    return data.get("package_map", {})
+    anchor = Path(data.get("workspace_root") or path.parent)
+    return {name: _resolve(share, anchor) for name, share in (data.get("package_map") or {}).items()}
+
+
+def _resolve(share: str, anchor: Path) -> str:
+    """Manifest paths are anchor-relative; absolute entries pass through unchanged."""
+    p = Path(share)
+    return share if p.is_absolute() else os.path.normpath(anchor / p)
 
 
 def find_package_map() -> Optional[Path]:


### PR DESCRIPTION
## Description

`ConfigRegistry` keys entities on a flat, global `full_name` (the `name:` field inside the YAML) and hard-raised on the first collision during the workspace-wide scan. Because the registry loads from **every** package manifest in the workspace — not just what the target needs — an unrelated duplicate anywhere in `src/` kills a build that never references it.

Concretely, building `autoware_system_design_examples` failed:

```
ValidationError: Duplicate entity 'Parking.module' found:
  New:      src/universe/.../autoware_universe_designs/design/planning/parking/Parking.module.yaml
  Existing: src/launcher/.../autoware_sample_designs/design/module/planning/Parking.module.yaml
```

`vehicle_x.system` does not use `Parking.module` at all.

In a general workspace, where packages are checked out from many repos and a design can be mid-migration between two of them, globally non-overlapping design files is not a condition a user can reasonably guarantee. **The scan phase should never fail the build.** A duplicate only matters if the deployed system actually uses that entity.

## Behavior

| phase | duplicate found |
|---|---|
| **scan** (`_load_entities`), any strictness | record it, log the collision summary at DEBUG, keep loading — never fatal |
| **use** (`_get_entity_with_base`), `STRICT=OFF` | `logger.warning` naming every candidate and marking the one in use; build continues |
| **use**, `STRICT=ON` | `ValidationError` after all modes are built and reported |
| **build failure** with used duplicates | hint at ERROR on stderr listing the duplicates that may have contributed |

### Which candidate wins

Selection is lazy and memoized per name (`EntityGroup.resolve`), ranked by `SelectionPolicy`:

1. **Preferred package** — the deployment package's copy wins outright;
2. **Anchor proximity** — fewest path steps from the deployment target's directory;
3. **Load order** (manifest filename order) breaks remaining ties.

The policy is pinned **before the first memoizing lookup**: for a path target the anchor is the target file's directory; for a bare `*.system` name (what the CMake macro passes) the target system group is peeked without memoization and the anchor/preferred package are derived from that pick, so the system, its base/variant chain, and every node/module lookup resolve under one final policy. A bare name that is itself duplicated warns explicitly (there is no path information to disambiguate; load order decides, deterministically).

All lookup keys, manifest entries, anchors, and ranking inputs share one canonical namespace (`utils/path_utils.canonical_path`, realpath-based and cached), so symlinked workspaces rank identically to their real paths.

Example warning:

```
WARNING - Duplicate entity 'Parking.module' is used by this deployment; '->' marks the definition in use:
  -> .../autoware_sample_designs/design/module/planning/Parking.module.yaml  [autoware_sample_designs]
     .../autoware_universe_designs/design/planning/parking/Parking.module.yaml  [autoware_universe_designs]
```

## Changes

### Duplicate tolerance and selection

- **`building/config/config_registry.py`** — entities live in `EntityGroup`s (every config declaring one `full_name`, in load order). `choose()` is a non-memoizing peek; `resolve()` memoizes and marks the group used; only used duplicates are reported and gated. `SelectionPolicy` ranks by preferred package → anchor proximity → load order. `iter_used_configs()` yields only memoized selections, so build-script generation consumes exactly the picks the deployment resolved; duplicates the deployment never uses neither warn nor trip the strict gate. The workspace-wide scan summary is DEBUG-only and lists candidates in load order.
- **`deploy.py`** — `_finalize_selection_policy` pins `anchor_dir` and `deployment_package_name` before `resolve_input_target` triggers the first resolution (peek via `peek_target_system_name` + `system_group().choose()`). `_check_used_duplicates` raises once per build under strict. Layer 1 reads the manifests once and carries `package_paths` forward.
- **`deployment/parser.py`** — adds `peek_target_system_name` (shared with the deployments-table mode).

### Anchor-relative manifests and path canonicalization

- **`utils/path_utils.py`** (new) — single owner of `canonical_path` (cached realpath), `resolve_manifest_path`, and the `_package_map.yaml` / `workspace_root` schema constants. `deploy.py`, the collector, and the standalone `tools/system-config-generator` mirror reference it (the latter two stay dependency-free by design, with role comments).
- **`script/collect_system_design_manifests.py`** — writes anchor-relative manifest entries with realpath keys end to end; `to_manifest_path` guards cross-drive `ValueError` and keeps outside-anchor paths absolute.
- **`CMakeLists.txt`** — `SYSTEM_DESIGN_MANIFEST_ANCHOR` is a `CACHE PATH` variable (overridable with `-D` for `--build-base` layouts), defaulting to the colcon sibling layout; the collector runs at install time with `--anchor`.
- **`deploy.py::_read_manifest_anchor`** — a recorded `workspace_root` absent on disk warns and falls back to the manifest directory. (Full install-tree relocatability is a follow-up.)

### Strictness plumbing and failure hints

- **`script/system_designer_runner.py`** — exports `AUTOWARE_SYSTEM_DESIGNER_STRICT` to the child process, so the Python layer knows the per-target strictness. **No CMake change needed** — the macro already forwards per-target `--strict`.
- **`utils/env.py`** (new) — one boolean env parser (`1/true/on/yes/y`, case-insensitive) used by `DeploymentConfig.from_env` for `STRICT` and `CACHE_ENABLED`; the stdlib-only runner keeps a matching local `_truthy`.
- **`deploy.py` / `script/deployment_process.py`** — `Deployment.__init__` attaches the registry to any exception it raises; the duplicate and minor-version hints read it there, so construction-time failures report too. Hints log at ERROR, which reaches stderr under the default print level. The hint import uses the `building` module path.

### Error-path hygiene

- **`building/instances/instance_tree.py`** — error wrappers chain their cause and tolerate `instance.configuration is None`; a strict duplicate error surfaces in the top-level `DeploymentError` together with the design-tree path.

### Tests (new)

- **`test/`** — first pytest suite for the package (registered via `ament_add_pytest_test`; `ament_cmake_pytest` / `python3-pytest` test-depends). 42 cases covering `SelectionPolicy` ranking and tie-breaks, `choose()`/`resolve()` memoization and `describe()` markers, canonical-path symlink unification, manifest path round-trips (including the stale-`workspace_root` fallback and collector relpath guards), env flag parsing, registry selection against real parsed design fixtures (anchor proximity, preferred-package tier, symlinked anchors, `iter_used_configs`), bare-name policy finalization, and the exception-attached registry.

## Tests performed

- `python3 -m pytest test/` — 42 passed.
- **`tools/build-example-systems.sh`** (`STRICT=ON`, the originally reported failure) — passes; `Parking.module` is duplicated but unused by `vehicle_x.system`.
- **Bare-name duplicated system** (synthetic two-package workspace) — warns once, picks by load order, and the node lookup follows the same package as the system pick; retargeting by file path flips both picks together.
- **Symlinked workspace** — same picks through a symlinked target path as through the real one; the preferred-package tier stays live.
- **Strict gate** — `AUTOWARE_SYSTEM_DESIGNER_STRICT=yes` fails the duplicated build with the full report; unused duplicates pass.
- **Construction failure** — a system referencing a missing node emits the used-duplicate hint on stderr with default `--print-level ERROR`.
- `pre-commit run --files` passes on all changed files (including the build-example-systems hook).

## Notes

The `Parking.module` duplicate itself is out of scope here. The two files are **byte-identical**, and `autoware_launch` commit `c4cda4b1b` ("migrate Parking module design from autoware_universe") was a move that never deleted the universe copy. It is the only duplicate in the workspace (357 design files, 356 distinct names). Deleting it belongs in a separate PR against `autoware_universe`; this change makes the tool tolerant regardless.

## Effects on system behavior

None for workspaces without duplicate entity names. Where duplicates exist, a build fails only when the deployed system uses the duplicated entity under strict; non-strict builds warn and continue. Used duplicates resolve deterministically: deployment package → anchor proximity → load order. Manifests record anchor-relative paths; absolute entries keep working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
