### PR TITLE
fix: stop reporting warnings the design data did not cause

### DIFF
--- a/autoware_system_designer/autoware_system_designer/building/parameters/parameter_manager.py
+++ b/autoware_system_designer/autoware_system_designer/building/parameters/parameter_manager.py
@@ -330,6 +330,7 @@ class ParameterManager:
         package_name: Optional[str] = None,
         is_override: bool = False,
         config_registry: Optional["ConfigRegistry"] = None,
+        resolver=None,
     ) -> str:
         """Resolve parameter file path with package prefix if needed.
 
@@ -338,6 +339,7 @@ class ParameterManager:
             package_name: The ROS package name for default parameters
             is_override: True for override parameter files, False for default
             config_registry: Registry to look up package paths
+            resolver: Substitution scope to resolve against; defaults to the instance resolver
 
         Returns:
             Resolved path with package prefix if applicable
@@ -349,8 +351,9 @@ class ParameterManager:
             )
 
         # Resolve any substitutions in the path first
-        if self.parameter_resolver:
-            path = self.parameter_resolver.resolve_string(path)
+        active_resolver = resolver or self.parameter_resolver
+        if active_resolver:
+            path = active_resolver.resolve_string(path)
 
         # If path is now absolute, return it
         if path.startswith("/"):
@@ -685,7 +688,17 @@ class ParameterManager:
         if self.instance.configuration and hasattr(self.instance.configuration, "package_name"):
             package_name = self.instance.configuration.package_name
 
-        # 1. Set default parameter_files from node configuration
+        # 1. Resolve param_values first: they are the node's launch-arg scope, so the node's own
+        # param files resolve their $(var ...) against them. The scope is a private copy, keeping
+        # one node's values out of its siblings' resolution.
+        resolved_param_values = self._resolve_node_param_values()
+        node_resolver = self.parameter_resolver
+        if resolved_param_values and node_resolver:
+            node_resolver = node_resolver.copy()
+            for entry in resolved_param_values:
+                node_resolver.variable_map[entry["name"]] = str(entry["value"])
+
+        # 2. Set default parameter_files from node configuration
         # Use new param_files field, fallback to parameter_files is handled in parser
         if hasattr(self.instance.configuration, "param_files") and self.instance.configuration.param_files:
             for idx, cfg_param in enumerate(self.instance.configuration.param_files):
@@ -700,8 +713,8 @@ class ParameterManager:
                     )
 
                 # Resolve parameter file path if resolver is available
-                if self.parameter_resolver:
-                    param_value = self.parameter_resolver.resolve_parameter_file_path(param_value, source=cfg_source)
+                if node_resolver:
+                    param_value = node_resolver.resolve_parameter_file_path(param_value, source=cfg_source)
 
                 # Add to parameter_files list
                 self.parameter_files.add_parameter_file(
@@ -720,39 +733,56 @@ class ParameterManager:
                     is_override=False,  # Node configuration parameter files are defaults
                     config_registry=config_registry,
                     source=cfg_source,
+                    resolver=node_resolver,
                 )
 
-        # 2. Set default parameters from node parameters
+        # 3. Set default parameters from node parameters
+        for entry in resolved_param_values:
+            self.parameters.set_parameter(
+                entry["name"],
+                entry["value"],
+                data_type=entry["type"],
+                allow_substs=True,
+                parameter_type=ParameterType.DEFAULT,  # These are default parameters
+                source=entry["source"],
+            )
+
+    def _resolve_node_param_values(self) -> List[Dict[str, Any]]:
+        """Resolve the node's param_values against the inherited substitution scope.
+
+        Entries whose value normalizes to None are dropped; the survivors both seed the
+        node's variable scope and become its DEFAULT parameters.
+        """
         # Use new param_values field, fallback to parameters is handled in parser
-        if hasattr(self.instance.configuration, "param_values") and self.instance.configuration.param_values:
-            for idx, cfg_param in enumerate(self.instance.configuration.param_values):
-                param_name = cfg_param.name
-                param_value = cfg_param.value
-                param_type = cfg_param.type
+        if not (hasattr(self.instance.configuration, "param_values") and self.instance.configuration.param_values):
+            return []
 
-                cfg_source = source_from_config(self.instance.configuration, f"/param_values/{idx}")
+        resolved: List[Dict[str, Any]] = []
+        for idx, cfg_param in enumerate(self.instance.configuration.param_values):
+            param_name = cfg_param.name
+            param_value = cfg_param.value
+            param_type = cfg_param.type
 
-                if param_name is None or param_value is None:
-                    raise ParameterConfigurationError(
-                        f"param_name or param_value is None. path: {self.instance.path}, param_values: {self.instance.configuration.param_values}"
-                    )
+            cfg_source = source_from_config(self.instance.configuration, f"/param_values/{idx}")
 
-                # Resolve parameter value if resolver is available
-                if self.parameter_resolver:
-                    param_value = self.parameter_resolver.resolve_parameter_value(param_value, source=cfg_source)
+            if param_name is None or param_value is None:
+                raise ParameterConfigurationError(
+                    f"param_name or param_value is None. path: {self.instance.path}, param_values: {self.instance.configuration.param_values}"
+                )
 
-                param_value = self._normalize_parameter_value(param_value, param_type, cfg_source)
+            # Resolve parameter value if resolver is available
+            if self.parameter_resolver:
+                param_value = self.parameter_resolver.resolve_parameter_value(param_value, source=cfg_source)
 
-                # Only set if a default value is provided
-                if param_value is not None:
-                    self.parameters.set_parameter(
-                        param_name,
-                        param_value,
-                        data_type=param_type,
-                        allow_substs=True,
-                        parameter_type=ParameterType.DEFAULT,  # These are default parameters
-                        source=cfg_source,
-                    )
+            param_value = self._normalize_parameter_value(param_value, param_type, cfg_source)
+
+            # Only set if a default value is provided
+            if param_value is None:
+                continue
+
+            resolved.append({"name": param_name, "value": param_value, "type": param_type, "source": cfg_source})
+
+        return resolved
 
     def _flatten_parameters(self, params: Dict[str, Any], parent_key: str = "", separator: str = ".") -> Dict[str, Any]:
         """Flatten nested dictionary into dot-separated keys.
@@ -794,6 +824,7 @@ class ParameterManager:
         is_override: bool,
         config_registry: "ConfigRegistry",
         source: Optional[SourceLocation],
+        resolver=None,
     ) -> Optional[str]:
         """Resolve a parameter file path to an existing absolute path (for visualization/template generation).
 
@@ -801,7 +832,9 @@ class ParameterManager:
         path can't be resolved to an existing absolute file.
         """
 
-        resolved_path = self._resolve_parameter_file_path(file_path, package_name, is_override, config_registry)
+        resolved_path = self._resolve_parameter_file_path(
+            file_path, package_name, is_override, config_registry, resolver=resolver
+        )
 
         # Only load when resolved to an absolute filesystem path with no remaining substitutions.
         if not resolved_path or resolved_path.startswith("$") or not os.path.isabs(resolved_path):
@@ -867,6 +900,7 @@ class ParameterManager:
         config_registry: Optional["ConfigRegistry"] = None,
         parameter_type: Optional[ParameterType] = None,
         source: Optional[SourceLocation] = None,
+        resolver=None,
     ):
         """Load parameters from a YAML file and add them to the parameter list."""
         if not config_registry:
@@ -880,6 +914,7 @@ class ParameterManager:
                 is_override,
                 config_registry,
                 source,
+                resolver=resolver,
             )
             if not existing_path:
                 return
@@ -903,9 +938,10 @@ class ParameterManager:
             if effective_type not in (ParameterType.DEFAULT_FILE, ParameterType.OVERRIDE_FILE, ParameterType.MODE_FILE):
                 return
 
+            active_resolver = resolver or self.parameter_resolver
             for p_name, p_value in flattened_params.items():
-                if self.parameter_resolver:
-                    p_value = self.parameter_resolver.resolve_parameter_value(p_value, source=source)
+                if active_resolver:
+                    p_value = active_resolver.resolve_parameter_value(p_value, source=source)
                 self.parameters.set_parameter(
                     p_name,
                     p_value,

--- a/autoware_system_designer/autoware_system_designer/building/parameters/parameter_resolver.py
+++ b/autoware_system_designer/autoware_system_designer/building/parameters/parameter_resolver.py
@@ -73,7 +73,8 @@ class ParameterResolver:
 
         # Regex patterns for substitutions
         self.env_pattern = re.compile(r"\$\(env\s+([^)]+)\)")
-        self.var_pattern = re.compile(r"\$\(var\s+([\w\.]+)\)")
+        # '/' is part of a name: ROS launch args are freely named, e.g. $(var group/enable)
+        self.var_pattern = re.compile(r"\$\(var\s+([\w./]+)\)")
         self.pkgshare_pattern = re.compile(r"\$\(find-pkg-share\s+([^)]+)\)")
         # eval_pattern removed in favor of manual parsing to support balanced parentheses
 

--- a/autoware_system_designer/autoware_system_designer/deployment/modes.py
+++ b/autoware_system_designer/autoware_system_designer/deployment/modes.py
@@ -25,6 +25,11 @@ from ..parsing.config import SystemConfig
 logger = logging.getLogger(__name__)
 
 
+def _declared_mode_names(system_config: SystemConfig) -> List[str]:
+    """Mode names declared under `modes`, regardless of whether they carry an override block."""
+    return [m.get("name") for m in (system_config.modes or []) if isinstance(m, dict)]
+
+
 def apply_mode_configuration(base_system_config: SystemConfig, mode_name: str) -> SystemConfig:
     """Create a copy of base system and apply mode-specific overrides/removals."""
 
@@ -48,12 +53,16 @@ def apply_mode_configuration(base_system_config: SystemConfig, mode_name: str) -
 
     mode_config = base_system_config.mode_configs.get(mode_name)
     if not mode_config:
-        src = source_from_config(base_system_config, "/modes")
-        logger.warning(
-            "Mode '%s' not found in mode_configs, using base configuration%s",
-            mode_name,
-            format_source(src),
-        )
+        # A declared mode carrying no override block is the base configuration itself.
+        if mode_name not in _declared_mode_names(base_system_config):
+            src = source_from_config(base_system_config, "/modes")
+            logger.warning(
+                "Mode '%s' not found in mode_configs, using base configuration%s",
+                mode_name,
+                format_source(src),
+            )
+        else:
+            logger.debug("Mode '%s' has no override block; using base configuration", mode_name)
         return modified_config
 
     logger.info("Applying mode configuration for mode '%s'", mode_name)

--- a/autoware_system_designer/autoware_system_designer/utils/logging_utils.py
+++ b/autoware_system_designer/autoware_system_designer/utils/logging_utils.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Optional
+from typing import Optional, Set, Tuple
 
 
 class _MaxLevelFilter(logging.Filter):
@@ -12,16 +12,37 @@ class _MaxLevelFilter(logging.Filter):
         return record.levelno <= self._max_level
 
 
+class _DedupeFilter(logging.Filter):
+    """Passes the first occurrence of each (logger, level, rendered message) triple.
+
+    A deployment is resolved once per mode, so a diagnostic about shared design data is
+    re-emitted verbatim for every mode. The repeats carry no mode context and therefore
+    no information.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._seen: Set[Tuple[str, int, str]] = set()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        key = (record.name, record.levelno, record.getMessage())
+        if key in self._seen:
+            return False
+        self._seen.add(key)
+        return True
+
+
 def configure_split_stream_logging(
     *,
     level: int = logging.INFO,
     stderr_level: int = logging.WARNING,
     formatter: Optional[logging.Formatter] = None,
+    dedupe_stderr: bool = True,
 ) -> None:
     """Configure root logging:
 
     - DEBUG/INFO go to stdout
-    - WARNING/ERROR/CRITICAL go to stderr
+    - WARNING/ERROR/CRITICAL go to stderr, each distinct message reported once
 
     This is intended to keep terminals clean while still allowing warnings/errors
     to be visible when callers suppress stdout (e.g., during builds).
@@ -44,6 +65,8 @@ def configure_split_stream_logging(
 
     stderr_handler = logging.StreamHandler(stream=sys.stderr)
     stderr_handler.setLevel(stderr_level)
+    if dedupe_stderr:
+        stderr_handler.addFilter(_DedupeFilter())
     stderr_handler.setFormatter(formatter)
 
     root.addHandler(stdout_handler)


### PR DESCRIPTION
## Description

Deployment builds emit warnings that no design change can resolve. This separates the tool's own noise from real design-data findings, so what remains is actionable.

Measured on `autoware_sample_designs` (which opts into `PRINT_LEVEL=WARNING`): **192 → 49** warning lines. Every remaining warning is a genuine design-data or packaging issue in the referenced package, untouched by this PR.

| Warning | Before | After |
|---|---:|---:|
| `Mode 'Runtime' not found in mode_configs` | 6 | **0** |
| `Undefined variable: $(var …)` | 33 | **2** |
| `Parameter file not found` | 136 | 34 |
| `No process found in <node>` | 13 | 5 |
| `Skipping connection targeting global input port` | 4 | 1 |

`autoware_system_design_examples` still builds clean under `STRICT=ON`.

## Changes

**A declared mode with no override block is the base configuration** — `deployment/modes.py`

Mode override blocks are top-level YAML keys named after the mode, so a mode that intentionally carries no overrides is simply absent from `mode_configs`. Only the literal name `default` was exempt, so a system's own default mode (e.g. `Runtime`, marked `default: true`) was reported as missing. Now any declared mode resolves to the base configuration silently; an *undeclared* mode still warns.

**A node's `param_values` are the scope its own `param_files` resolve against** — `building/parameters/parameter_manager.py`

This is already the contract the launcher template emits: `node_launcher.xml.jinja2` turns each `param_values` entry into an `<arg>` and loads the node's param files in that same arg scope. The in-process `ParameterResolver` never saw them — `variable_map` is fed only from system `variables`/`variable_files` and parameter-set scopes — and `param_files` were consumed before `param_values` were even read. Every `$(var …)` inside a node's own param file was therefore undefined.

`param_values` are now resolved first and seeded into a **private copy** of the inherited resolver, which is threaded explicitly into the param-file loading path. The copy matters: the resolver instance is shared down the whole instance tree, so seeding the shared map would let one node's values leak into its siblings' resolution. Scoping per node also matches the generated-launch semantics exactly.

**`$(var …)` names may contain `/`** — `building/parameters/parameter_resolver.py`

ROS launch args are freely named, and slash-separated names are used in practice (`pose_initializer.launch.xml` declares `user_defined_initial_pose/enable`). The pattern `[\w\.]+` could not match them, so such substitutions were not recognized at all and passed through silently — the one failure mode with no diagnostic. They are now matched, and resolve or warn like any other name.

**Repeated diagnostics** — `utils/logging_utils.py`

A deployment is resolved once per mode, so a diagnostic about shared design data was re-emitted verbatim for every mode. The repeats carry no mode context, so nothing distinguishes them. The stderr handler now passes the first occurrence of each `(logger, level, message)` triple; `dedupe_stderr=False` restores the old behavior.

## Effects on generated output

None. Verified by diffing all 732 exported files for `autoware_sample_designs` before and after: identical apart from `generated_at` timestamps. `param_values` are `DEFAULT` (priority 2) and file-loaded values are `DEFAULT_FILE` (priority 1), so the unresolved literals were already being overridden — only the reporting changed.

## Notes

Widening the `$(var …)` pattern surfaces two warnings that were previously silent, both a real bug in `autoware_pose_initializer`: `PoseInitializer.node.yaml` declares `user_defined_initial_pose.enable/.pose` with dots, while the param file and the upstream launch args use slashes. Those two parameters never resolved and still do not — now it is visible. Fix belongs in `autoware_core`.

Not addressed here, needing a format decision rather than a code fix: `No process found in <node>` cannot distinguish "process modelling not filled in yet" from "nothing to model" (an external process such as RViz or a simulator). Both spell it `processes: []`.

## Tests

- `colcon build --packages-select autoware_system_designer autoware_sample_designs autoware_system_design_examples` — all pass; examples clean under `STRICT=ON`
- All 732 generated export files byte-identical modulo timestamps
- `pre-commit run --files <changed>` — pass
