### PR TITLE
fix: serialize generated param attributes as YAML-safe scalars

### DIFF
--- a/autoware_system_designer/autoware_system_designer/file_io/template_renderer.py
+++ b/autoware_system_designer/autoware_system_designer/file_io/template_renderer.py
@@ -7,6 +7,8 @@ import os
 
 from jinja2 import Environment, FileSystemLoader
 
+from ..utils.parameter_types import to_launch_param_attr
+
 
 def _get_template_directories() -> list[str]:
     """Resolve template search paths.
@@ -80,6 +82,7 @@ class TemplateRenderer:
             autoescape=False,
         )
         self.env.filters["tojson"] = json.dumps
+        self.env.filters["launch_param_attr"] = to_launch_param_attr
 
     def render_template(self, template_name: str, **kwargs) -> str:
         template = self.env.get_template(template_name)

--- a/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
+++ b/autoware_system_designer/autoware_system_designer/ros2_launcher/templates/component_launcher.xml.jinja2
@@ -17,21 +17,21 @@
 <!-- Parameters - Non-Override Parameters -->
 {% for param in node.param_values %}
 {% if param.parameter_type != 'OVERRIDE' and param.parameter_type != 'OVERRIDE_FILE' and param.parameter_type != 'MODE' and param.parameter_type != 'MODE_FILE' %}
-<param name="{{ param.name }}" value="{{ param.value }}"/>
+<param name="{{ param.name }}" value="{{ param.value | launch_param_attr }}"/>
 {% endif %}
 {% endfor %}
 
 <!-- Parameters - Overrides -->
 {% for param in node.param_values %}
 {% if param.parameter_type == 'OVERRIDE' or param.parameter_type == 'OVERRIDE_FILE' %}
-<param name="{{ param.name }}" value="{{ param.value }}"/>
+<param name="{{ param.name }}" value="{{ param.value | launch_param_attr }}"/>
 {% endif %}
 {% endfor %}
 
 <!-- Parameters - Mode Overrides (highest priority) -->
 {% for param in node.param_values %}
 {% if param.parameter_type == 'MODE' or param.parameter_type == 'MODE_FILE' %}
-<param name="{{ param.name }}" value="{{ param.value }}"/>
+<param name="{{ param.name }}" value="{{ param.value | launch_param_attr }}"/>
 {% endif %}
 {% endfor %}
 {% endmacro %}

--- a/autoware_system_designer/autoware_system_designer/utils/parameter_types.py
+++ b/autoware_system_designer/autoware_system_designer/utils/parameter_types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
 
+import yaml
+
 STRING_TYPES = {"string", "str"}
 BOOL_TYPES = {"bool", "boolean"}
 INTEGER_TYPES = {
@@ -82,3 +84,23 @@ def coerce_numeric_value(value: Any, type_name: Optional[str]) -> Any:
         return float(dec)
 
     raise ValueError(f"Invalid numeric value '{value}' for type '{type_name}'")
+
+
+def to_launch_param_attr(value: Any) -> str:
+    """Serialize a parameter value for a launch XML ``value`` attribute.
+
+    The XML frontend re-parses the attribute as YAML: a bare string that reads
+    back as YAML null (``null``, ``~``, empty) is single-quoted so it stays a
+    string; lists are emitted as YAML flow sequences.
+    """
+    if isinstance(value, (list, tuple)):
+        return yaml.safe_dump(list(value), default_flow_style=True, width=1_000_000_000).strip()
+    if isinstance(value, str):
+        try:
+            reparsed = yaml.safe_load(value)
+        except yaml.YAMLError:
+            reparsed = value
+        if reparsed is None:
+            return "'" + value.replace("'", "''") + "'"
+        return value
+    return str(value)

--- a/autoware_system_designer/test/test_launch_param_attr.py
+++ b/autoware_system_designer/test/test_launch_param_attr.py
@@ -1,0 +1,53 @@
+# Copyright 2026 TIER IV, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+
+from autoware_system_designer.file_io.template_renderer import TemplateRenderer
+from autoware_system_designer.utils.parameter_types import to_launch_param_attr
+
+
+def test_null_like_strings_stay_strings():
+    for text in ["null", "Null", "NULL", "~", ""]:
+        attr = to_launch_param_attr(text)
+        assert yaml.safe_load(attr) == text
+
+
+def test_plain_strings_pass_through():
+    assert to_launch_param_attr("general_vehicle_tracker") == "general_vehicle_tracker"
+    assert to_launch_param_attr("$(var map_path)/pointcloud_map.pcd") == "$(var map_path)/pointcloud_map.pcd"
+
+
+def test_string_with_quotes_is_escaped():
+    attr = to_launch_param_attr("it's null")
+    assert yaml.safe_load(attr) == "it's null"
+
+
+def test_scalars_keep_current_rendering():
+    assert to_launch_param_attr(True) == "True"
+    assert to_launch_param_attr(0.5) == "0.5"
+    assert to_launch_param_attr(3) == "3"
+
+
+def test_lists_roundtrip_through_yaml():
+    values = [["a", "b"], ["null"], [1, 2], [0.1, 0.2], ["with, comma"]]
+    for value in values:
+        attr = to_launch_param_attr(value)
+        assert "\n" not in attr
+        assert yaml.safe_load(attr) == value
+
+
+def test_template_filter_is_registered():
+    renderer = TemplateRenderer()
+    assert renderer.env.filters["launch_param_attr"] is to_launch_param_attr


### PR DESCRIPTION
## Description

Generated component launchers render flattened parameter values into `<param value="...">` XML attributes, which the ROS 2 launch frontend re-parses as YAML. A string value of `"null"` — used as an explicit sentinel in e.g. `autoware_multi_object_tracker`'s `data_association_matrix.param.yaml` (`animal: {create: "null"}`) — loses its quoting on the way through and comes back as YAML null, which is not a valid parameter type. Loading the exported launcher then aborts:

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught multiple exceptions when trying to load file of format [xml]:
 - TypeError: Attribute 'value' of Entity 'param' expected to be of type 'None'.'null' can not be converted to one of those types
 - SyntaxError: invalid syntax (perception.launch.xml, line 1)
```

(The `SyntaxError` is launch falling back to the Python frontend; the `TypeError` is the real failure.)

## Changes

- Add `to_launch_param_attr()` (`utils/parameter_types.py`): serializes a parameter value for a launch XML `value` attribute. Strings whose YAML round-trip is null (`null`, `~`, empty) are single-quoted so they stay strings; lists are emitted as YAML flow sequences instead of Python `repr`. All other values keep their current rendering.
- Register it as the `launch_param_attr` Jinja filter (`file_io/template_renderer.py`) and apply it to the three `<param ... value=...>` sites in `component_launcher.xml.jinja2`.
- Unit tests covering null-like strings, quote escaping, pass-through of plain strings/substitutions/scalars, and list round-trips.

## Verification

- `pytest test/` — 48 passed.
- Rebuilt `autoware_sample_designs`; the exported `LoggingSimulation/main_ecu/perception/perception.launch.xml` now renders `value="'null'"` for the affected `tracker_assignment.*.create` params, and `ros2 launch --print .../main_ecu/main_ecu.launch.xml` loads the full description without errors (previously failed at parse).
- `pre-commit` on the changed files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
